### PR TITLE
Optimize BitSet.copy method

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/BitSet.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/BitSet.scala
@@ -67,8 +67,7 @@ case class BitSet(val length: Int)(private val bits: Array[Long] = Array.fill(le
   }
 
   def copy(): BitSet = {
-    val newBitsArray = new Array[Long](this.bits.length)
-    System.arraycopy(this.bits, 0, newBitsArray, 0, this.bits.length)
+  val newBitsArray = this.bits.clone()
     new BitSet(this.length)(newBitsArray)
   }
 


### PR DESCRIPTION
I replaced System.arraycopy with this.bits.clone() in the BitSet.copy method.

Using array.clone() can be slightly more performant for primitive arrays as it may involve less overhead compared to System.arraycopy. This change aims to provide a micro-optimization for the copy operation as part of an "extreme tuning" effort for the BitSet class. The functional behavior of the copy method remains identical.