### PR TITLE
feat: Implement NPS benchmarking for AI players

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V1.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V1.scala
@@ -9,7 +9,7 @@ class AlphaBetaAI_V1(val name: String = "AlphaBetaAI_V1", searchDepth: Int) exte
       board: Board,          // Current board configuration
       turn: Turn,            // The player whose turn it is (should be this AI's turn)
       currentSearchDepth: Int // Search depth to use for this call (can override default)
-  ): Option[Transition] = {
+  ): (Option[Transition], Long) = { // Changed return type
 
     // The 'turn' parameter here is the turn for which the AI is being asked to find a move.
     // This should align with the AI's own configured turn if it's a game play situation.
@@ -26,7 +26,8 @@ class AlphaBetaAI_V1(val name: String = "AlphaBetaAI_V1", searchDepth: Int) exte
     // 'turn' is passed as 'rootPlayerTurn' to ensure evaluation is from this AI's perspective.
     val initialBoardID = ID(board) // Generate ID for the initial board state
 
-    val (_, bestMoveOpt) = AlphaBetaSearch.search(
+    // Destructure to get nodesVisited
+    val (_, bestMoveOpt, nodesVisited) = AlphaBetaSearch.search(
       currentState = state,
       currentBoard = board,
       currentBoardID = initialBoardID,
@@ -39,7 +40,7 @@ class AlphaBetaAI_V1(val name: String = "AlphaBetaAI_V1", searchDepth: Int) exte
       evalFunc = EvaluationV1.evaluate
     )
 
-    bestMoveOpt
+    (bestMoveOpt, nodesVisited) // Return nodesVisited
   }
 
   override def toString: String = s"$name(depth=$searchDepth)"

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V2.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V2.scala
@@ -13,7 +13,7 @@ class AlphaBetaAI_V2(val name: String = "AlphaBetaAI_V2", searchDepth: Int) exte
       board: Board,
       turn: Turn,
       currentSearchDepth: Int // Use this depth for the search
-  ): Option[Transition] = {
+  ): (Option[Transition], Long) = { // Changed return type
 
     // Initial alpha/beta for the root search.
     // AlphaBetaSearch itself will initialize its internal currentMaxEval/currentMinEval
@@ -23,7 +23,8 @@ class AlphaBetaAI_V2(val name: String = "AlphaBetaAI_V2", searchDepth: Int) exte
 
     val initialBoardID = ID(board) // Generate ID for the initial board state
 
-    val (_, bestMoveOpt) = AlphaBetaSearch.search(
+    // Destructure to get nodesVisited
+    val (_, bestMoveOpt, nodesVisited) = AlphaBetaSearch.search(
       currentState = state,
       currentBoard = board,
       currentBoardID = initialBoardID,
@@ -36,7 +37,7 @@ class AlphaBetaAI_V2(val name: String = "AlphaBetaAI_V2", searchDepth: Int) exte
       evalFunc = EvaluationV2.evaluate
     )
 
-    bestMoveOpt
+    (bestMoveOpt, nodesVisited) // Return nodesVisited
   }
 
   override def toString: String = s"$name(depth=$searchDepth)"

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearch.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearch.scala
@@ -21,7 +21,9 @@ object AlphaBetaSearch {
       maximizingPlayer: Boolean, // Is the current node/depth for the maximizing player?
       rootPlayerTurn: Turn, // The AI player for whom we are searching at the root
       evalFunc: (Board, Turn) => Int // Evaluates from the perspective of rootPlayerTurn
-  ): (Int, Option[Transition]) = {
+  ): (Int, Option[Transition], Long) = { // Added Long for node count
+
+    var nodesVisitedAccumulator: Long = 1L // Initialize node counter
 
     // Repetition check
     if (gamePathHistoryIDs.count(_ == currentBoardID) >= 2) {
@@ -29,7 +31,7 @@ object AlphaBetaSearch {
       // This means the current occurrence is the 3rd (or more) time.
       // Return a draw score (0) to discourage loops.
       // println(s"AlphaBeta DEBUG (depth $depth): Repetition detected for ID ${currentBoardID.toString.take(6)}... Draw score 0.")
-      return (0, None)
+      return (0, None, nodesVisitedAccumulator) // Added nodesVisitedAccumulator
     }
 
     // TODO: Add checkmate detection if Rule.isCheckmate is available. For now, rely on depth and no moves.
@@ -40,7 +42,7 @@ object AlphaBetaSearch {
     if (depth == 0) {
       val score = evalFunc(currentBoard, rootPlayerTurn)
       // println(s"AlphaBeta DEBUG (depth 0, eval for $rootPlayerTurn): Evaluated score = $score") // Restored
-      return (score, None)
+      return (score, None, nodesVisitedAccumulator) // Added nodesVisitedAccumulator
     }
 
     // Utils.plans uses currentState.turn to determine whose moves to generate
@@ -72,7 +74,7 @@ object AlphaBetaSearch {
       } else {
         MATE_SCORE + depth  // Opponent is checkmated, good for rootPlayerTurn
       }
-      return (score, None) // No move to make
+      return (score, None, nodesVisitedAccumulator) // No move to make, Added nodesVisitedAccumulator
     }
 
 
@@ -99,12 +101,13 @@ object AlphaBetaSearch {
         // } // Restored
 
         val nextBoardID = ID(tempBoard) // Generate ID for the new board state
-        val (eval, returnedMoveOpt) = search(nextState, tempBoard, nextBoardID,
+        val (eval, returnedMoveOpt, childNodesVisited) = search(nextState, tempBoard, nextBoardID, // Capture childNodesVisited
                                              currentBoardID :: gamePathHistoryIDs, // Prepend current ID to history for child
                                              depth - 1, currentAlpha, beta, false, rootPlayerTurn, evalFunc)
+        nodesVisitedAccumulator += childNodesVisited // Accumulate child nodes
 
         // if (depth == 2) { // Logging for root node's decision process // Restored
-            // println(s"ROOT MAX NODE: Move ${move.oldPos}->${move.newPos} (child chose ${returnedMoveOpt.map(m=>m.oldPos+"->"+m.newPos)}) resulted in eval $eval.") // Restored
+            // println(s"ROOT MAX NODE: Move ${move.oldPos}->${move.newPos} (child chose ${returnedMoveOpt.map(m=>m.oldPos+"->"+m.newPos)}) resulted in eval $eval. Child nodes: $childNodesVisited") // Restored
             // println(s"ROOT MAX NODE: Comparing eval $eval with currentMaxEval $currentMaxEval.") // Restored
         // } // Restored
 
@@ -142,7 +145,7 @@ object AlphaBetaSearch {
                 //  println(s"ROOT MAX NODE: BETA CUTOFF: Best move was None, set to legalMoves.head ${legalMoves.head.oldPos} -> ${legalMoves.head.newPos}") // Restored
             //  } // Restored
           }
-          return (currentMaxEval, bestMoveForThisNode) // Beta cut-off
+          return (currentMaxEval, bestMoveForThisNode, nodesVisitedAccumulator) // Beta cut-off, Added nodesVisitedAccumulator
         }
       } // end for loop
 
@@ -153,9 +156,9 @@ object AlphaBetaSearch {
         // } // Restored
       }
       // if (depth == 2) { // Restored
-        // println(s"ROOT MAX NODE (depth $depth): Loop finished. Returning score $currentMaxEval, move: ${bestMoveForThisNode.map(m => m.oldPos + "->" + m.newPos)}") // Restored
+        // println(s"ROOT MAX NODE (depth $depth): Loop finished. Returning score $currentMaxEval, move: ${bestMoveForThisNode.map(m => m.oldPos + "->" + m.newPos)}. Total nodes: $nodesVisitedAccumulator") // Restored
       // } // Restored
-      return (currentMaxEval, bestMoveForThisNode)
+      return (currentMaxEval, bestMoveForThisNode, nodesVisitedAccumulator) // Added nodesVisitedAccumulator
     } else { // MINIMIZING PLAYER (Gote's turn at depth 1 for this test)
       var currentMinEval = Int.MaxValue
       var bestMoveForThisNode: Option[Transition] = None
@@ -178,12 +181,13 @@ object AlphaBetaSearch {
         // } // Restored
 
         val nextBoardID = ID(tempBoard) // Generate ID for the new board state
-        val (eval, returnedMoveOpt) = search(nextState, tempBoard, nextBoardID,
+        val (eval, returnedMoveOpt, childNodesVisited) = search(nextState, tempBoard, nextBoardID, // Capture childNodesVisited
                                              currentBoardID :: gamePathHistoryIDs, // Prepend current ID to history for child
                                              depth - 1, alpha, currentBeta, true, rootPlayerTurn, evalFunc)
+        nodesVisitedAccumulator += childNodesVisited // Accumulate child nodes
 
         // if (depth == 1) { // Restored
-            // println(s"MIN NODE: Gote Move ${move.oldPos}->${move.newPos} (child Sente MAX node chose ${returnedMoveOpt.map(m=>m.oldPos+"->"+m.newPos)}) resulted in eval $eval (Sente's perspective).") // Restored
+            // println(s"MIN NODE: Gote Move ${move.oldPos}->${move.newPos} (child Sente MAX node chose ${returnedMoveOpt.map(m=>m.oldPos+"->"+m.newPos)}) resulted in eval $eval (Sente's perspective). Child nodes: $childNodesVisited") // Restored
             // println(s"MIN NODE: Comparing eval $eval with currentMinEval $currentMinEval.") // Restored
         // } // Restored
         if (eval < currentMinEval) {
@@ -205,7 +209,7 @@ object AlphaBetaSearch {
                     bestMoveForThisNode = Some(legalMoves.head)
                 }
             }
-            return (currentMinEval, bestMoveForThisNode) // Alpha cut-off
+            return (currentMinEval, bestMoveForThisNode, nodesVisitedAccumulator) // Alpha cut-off, Added nodesVisitedAccumulator
         }
       }
       if (bestMoveForThisNode.isEmpty && legalMoves.nonEmpty) {
@@ -213,9 +217,9 @@ object AlphaBetaSearch {
         // if (depth == 1) println(s"MIN NODE (depth $depth): Fallback post-loop: Gote chose legalMoves.head: ${legalMoves.head.oldPos} -> ${legalMoves.head.newPos} because bestMove was None (resulting Sente score $currentMinEval).") // Restored
       }
       // if (depth == 1) { // Restored
-        // println(s"MIN NODE (depth $depth): Loop finished. Gote returns score $currentMinEval (for Sente), Gote's chosen move: ${bestMoveForThisNode.map(m => m.oldPos + "->" + m.newPos)}") // Restored
+        // println(s"MIN NODE (depth $depth): Loop finished. Gote returns score $currentMinEval (for Sente), Gote's chosen move: ${bestMoveForThisNode.map(m => m.oldPos + "->" + m.newPos)}. Total nodes: $nodesVisitedAccumulator") // Restored
       // } // Restored
-      return (currentMinEval, bestMoveForThisNode)
+      return (currentMinEval, bestMoveForThisNode, nodesVisitedAccumulator) // Added nodesVisitedAccumulator
     }
   }
 }

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/ShogiAI.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/ShogiAI.scala
@@ -10,7 +10,7 @@ trait ShogiAI {
    * @param board The current board configuration (derived from state, or passed for efficiency).
    * @param turn The player whose turn it is.
    * @param currentSearchDepth The depth for the current search iteration.
-   * @return An Option[Transition] representing the best move found, or None if no move is possible/found.
+   * @return A tuple containing an Option[Transition] representing the best move found (or None) and a Long representing the number of nodes visited.
    */
-  def findBestMove(state: State, board: Board, turn: Turn, currentSearchDepth: Int): Option[Transition]
+  def findBestMove(state: State, board: Board, turn: Turn, currentSearchDepth: Int): (Option[Transition], Long)
 }

--- a/src/core/src/main/scala/jp/sndyuk/shogi/player/AIPlayer.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/player/AIPlayer.scala
@@ -23,8 +23,9 @@ class AIPlayer(
     println(s"AIPlayer ($name, $turn) is thinking using ${ai.getClass.getSimpleName} with depth $defaultSearchDepth for turn ${state.turn}...")
 
     ai.findBestMove(state, board, this.turn, defaultSearchDepth) match {
-      case Some(move) => move
-      case None =>
+      case (Some(move), _) => // Destructure tuple, ignore nodesVisited for return
+        move
+      case (None, _) => // Destructure tuple, ignore nodesVisited for return
         // This situation (AI returns None) should ideally be handled by the game logic
         // if it means no legal moves (checkmate/stalemate).
         // If it's an unexpected AI failure, throwing an exception is reasonable.

--- a/src/sample/src/main/scala/jp/sndyuk/shogi/ui/AIBattleSim.scala
+++ b/src/sample/src/main/scala/jp/sndyuk/shogi/ui/AIBattleSim.scala
@@ -38,9 +38,14 @@ object AIBattleSim extends App {
     // AIPlayer passes its own turn to findBestMove's 'turn' param.
     // The 'currentSearchDepth' for findBestMove will be AI's configured depth.
     val searchDepthForThisTurn = if (currentAiPlayer == PlayerA) SEARCH_DEPTH_AI1 else SEARCH_DEPTH_AI2
-    val bestMoveOpt = currentAi.findBestMove(currentState, board, currentAiPlayer, searchDepthForThisTurn)
+    val (bestMoveOpt, nodesVisited) = currentAi.findBestMove(currentState, board, currentAiPlayer, searchDepthForThisTurn)
     val endTime = System.currentTimeMillis()
-    println(s"Thinking time: ${endTime - startTime}ms")
+    val thinkingTime = endTime - startTime // Store for NPS calculation
+    println(s"Thinking time: ${thinkingTime}ms")
+    val thinkingTimeSeconds = thinkingTime / 1000.0
+    val nps = if (thinkingTimeSeconds > 0) nodesVisited / thinkingTimeSeconds else 0.0
+    println(s"Nodes visited: $nodesVisited")
+    println(s"NPS: ${"%.2f".format(nps)}")
 
     bestMoveOpt match {
       case Some(move) =>


### PR DESCRIPTION
This commit introduces Nodes Per Second (NPS) benchmarking capabilities to the Shogi AI.

The following changes were made:

1.  Modified `AlphaBetaSearch.scala`:
    - The `search` method now counts the number of nodes visited during its execution.
    - It returns this node count along with the evaluation score and the best move.

2.  Updated AI implementations (`AlphaBetaAI_V1.scala`, `AlphaBetaAI_V2.scala`):
    - Their `findBestMove` methods now receive the node count from `AlphaBetaSearch.search`.
    - They return both the chosen move and the total nodes visited.

3.  Adjusted `ShogiAI.scala` (AI interface):
    - The `findBestMove` method signature in the `ShogiAI` trait was updated to reflect the new return type `(Option[Transition], Long)`.

4.  Patched `AIPlayer.scala`:
    - The `play` method, which uses an AI to select moves, was updated to correctly handle the new return signature of `findBestMove`. This was an initially missed step that I identified and resolved during testing.

5.  Enhanced `AIBattleSim.scala`:
    - The simulation now retrieves the number of nodes visited from the AI's `findBestMove` method.
    - It calculates NPS by dividing the nodes visited by the thinking time in seconds.
    - Both the total nodes visited and the calculated NPS are printed to the console for each AI move.

I ran the `AIBattleSim` to verify these changes, confirming that the simulation executes correctly and the NPS/node count metrics are displayed as expected.