### PR TITLE
I've fixed the console error handling, a bug in ShogiGameService, and…

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
@@ -292,9 +292,10 @@ class ShogiGameService {
             val toWebX = 9 - toCorePos.x
             val toWebY = toCorePos.y - 1
 
-            val pieceTypeStr: String = GameStateMapper.corePieceToSimplePieceTypeAndPlayer(coreTrans.piece) match {
+            val movingPiece: Piece = currentBoardCopy.piece(coreTrans.oldPos, turnForAI)
+            val pieceTypeStr: String = GameStateMapper.corePieceToSimplePieceTypeAndPlayer(movingPiece) match {
               case Some((spt, _, _)) => spt.toString
-              case None => coreTrans.piece.toString // Fallback, though should ideally map
+              case None => movingPiece.toString // Fallback, though should ideally map
             }
 
             val promotionBool: Boolean = coreTrans.nari

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/GameSaverSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/GameSaverSpec.scala
@@ -3,12 +3,11 @@ package jp.sndyuk.shogi.core
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import java.nio.file.{Files, Path}
-import jp.sndyuk.shogi.core.SimplePiece.SimplePieceType
 // PieceInfo is now part of GameState, so if GameState is imported, PieceInfo should be accessible.
 // Or import jp.sndyuk.shogi.core.GameState.PieceInfo if needed, assuming it's defined in GameState object
 // For SavedTransition, boardStateAfterMove now uses Map[String, PieceInfo] as per recent changes
 // We need PieceInfo for the updated boardSetup types.
-import jp.sndyuk.shogi.core.PieceInfo
+import jp.sndyuk.shogi.core.{PieceInfo => CorePieceInfo}
 import jp.sndyuk.shogi.core.{SimpleTransition => SavedTransition}
 
 
@@ -26,33 +25,33 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
   // Helper to convert Position (1-indexed) to "x_y" string key (0-indexed core Point x,y)
   private def posToKey(pos: Position): String = s"${9 - pos.x}_${pos.y - 1}"
 
-  // Sample data for board setup using PieceInfo
-  val sampleBoardSetup: Map[String, PieceInfo] = Map(
-    posToKey(Position(1, 1)) -> PieceInfo(SimplePiece.KY, Player.SENTE, isPromoted = false),
-    posToKey(Position(1, 2)) -> PieceInfo(SimplePiece.KE, Player.SENTE, isPromoted = false),
-    posToKey(Position(5, 5)) -> PieceInfo(SimplePiece.OU, Player.SENTE, isPromoted = false)
+  // Sample data for board setup using CorePieceInfo
+  val sampleBoardSetup: Map[String, CorePieceInfo] = Map(
+    posToKey(Position(1, 1)) -> CorePieceInfo(SimplePiece.KY, Player.SENTE, isPromoted = false),
+    posToKey(Position(1, 2)) -> CorePieceInfo(SimplePiece.KE, Player.SENTE, isPromoted = false),
+    posToKey(Position(5, 5)) -> CorePieceInfo(SimplePiece.OU, Player.SENTE, isPromoted = false)
   )
 
-  val sampleBoardSetupMidGame: Map[String, PieceInfo] = Map(
-    posToKey(Position(7, 6)) -> PieceInfo(SimplePiece.FU, Player.SENTE, isPromoted = false), // Sente FU
-    posToKey(Position(3, 4)) -> PieceInfo(SimplePiece.FU, Player.GOTE, isPromoted = false),  // Gote FU
-    posToKey(Position(5, 8)) -> PieceInfo(SimplePiece.OU, Player.SENTE, isPromoted = false), // Sente OU
-    posToKey(Position(5, 2)) -> PieceInfo(SimplePiece.OU, Player.GOTE, isPromoted = false),  // Gote OU
-    posToKey(Position(2, 2)) -> PieceInfo(SimplePiece.HI, Player.GOTE, isPromoted = false),  // Gote HI
-    posToKey(Position(8, 8)) -> PieceInfo(SimplePiece.KA, Player.SENTE, isPromoted = false)  // Sente KA
+  val sampleBoardSetupMidGame: Map[String, CorePieceInfo] = Map(
+    posToKey(Position(7, 6)) -> CorePieceInfo(SimplePiece.FU, Player.SENTE, isPromoted = false), // Sente FU
+    posToKey(Position(3, 4)) -> CorePieceInfo(SimplePiece.FU, Player.GOTE, isPromoted = false),  // Gote FU
+    posToKey(Position(5, 8)) -> CorePieceInfo(SimplePiece.OU, Player.SENTE, isPromoted = false), // Sente OU
+    posToKey(Position(5, 2)) -> CorePieceInfo(SimplePiece.OU, Player.GOTE, isPromoted = false),  // Gote OU
+    posToKey(Position(2, 2)) -> CorePieceInfo(SimplePiece.HI, Player.GOTE, isPromoted = false),  // Gote HI
+    posToKey(Position(8, 8)) -> CorePieceInfo(SimplePiece.KA, Player.SENTE, isPromoted = false)  // Sente KA
   )
 
-  // For history, boardStateAfterMove now expects Map[String, PieceInfo]
+  // For history, boardStateAfterMove now expects Map[String, CorePieceInfo]
   val sampleHistory: List[SavedTransition] = List(
-    SavedTransition("7g7f", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> PieceInfo(SimplePiece.FU, Player.SENTE, false))),
-    SavedTransition("3c3d", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> PieceInfo(SimplePiece.FU, Player.SENTE, false)) - posToKey(Position(3,3)) + (posToKey(Position(3,4)) -> PieceInfo(SimplePiece.FU, Player.GOTE, false)))
+    SavedTransition("7g7f", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> CorePieceInfo(SimplePiece.FU, Player.SENTE, false))),
+    SavedTransition("3c3d", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> CorePieceInfo(SimplePiece.FU, Player.SENTE, false)) - posToKey(Position(3,3)) + (posToKey(Position(3,4)) -> CorePieceInfo(SimplePiece.FU, Player.GOTE, false)))
   )
 
   val emptyHistory: List[SavedTransition] = Nil
 
   "GameSaver" should "save and load a simple game state correctly" in withTempFile { filePath =>
     val originalGameState = GameState(
-      boardSetup = sampleBoardSetup, // This is now Map[String, PieceInfo]
+      boardSetup = sampleBoardSetup, // This is now Map[String, CorePieceInfo]
       currentTurn = Player.SENTE,
       capturedPiecesPlayer1 = List(SimplePiece.KA, SimplePiece.FU),
       capturedPiecesPlayer2 = List(SimplePiece.HI),
@@ -66,7 +65,7 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
     loadResult should be a 'success
 
     val loadedGameState = loadResult.get
-    // Custom equality check for PieceInfo maps
+    // Custom equality check for CorePieceInfo maps
     loadedGameState.boardSetup.keys should contain theSameElementsAs originalGameState.boardSetup.keys
     originalGameState.boardSetup.keys.foreach { k =>
         loadedGameState.boardSetup(k) shouldEqual originalGameState.boardSetup(k)
@@ -76,12 +75,12 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "save and load an initial game state" in withTempFile { filePath =>
-    val initialBoard: Map[String, PieceInfo] = Map(
-      posToKey(Position(1,1)) -> PieceInfo(SimplePiece.KY, Player.SENTE, false), posToKey(Position(2,1)) -> PieceInfo(SimplePiece.KE, Player.SENTE, false),
-      posToKey(Position(9,9)) -> PieceInfo(SimplePiece.KY, Player.GOTE, false), posToKey(Position(8,9)) -> PieceInfo(SimplePiece.KE, Player.GOTE, false)
+    val initialBoard: Map[String, CorePieceInfo] = Map(
+      posToKey(Position(1,1)) -> CorePieceInfo(SimplePiece.KY, Player.SENTE, false), posToKey(Position(2,1)) -> CorePieceInfo(SimplePiece.KE, Player.SENTE, false),
+      posToKey(Position(9,9)) -> CorePieceInfo(SimplePiece.KY, Player.GOTE, false), posToKey(Position(8,9)) -> CorePieceInfo(SimplePiece.KE, Player.GOTE, false)
     )
     val originalGameState = GameState(
-      boardSetup = initialBoard, // This is now Map[String, PieceInfo]
+      boardSetup = initialBoard, // This is now Map[String, CorePieceInfo]
       currentTurn = Player.SENTE,
       capturedPiecesPlayer1 = Nil,
       capturedPiecesPlayer2 = Nil,
@@ -98,14 +97,14 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "save and load a mid-game state with more complex data" in withTempFile { filePath =>
-    // boardStateAfterMove now expects Map[String, PieceInfo]
+    // boardStateAfterMove now expects Map[String, CorePieceInfo]
     val complexHistory = List(
-        SavedTransition("7g7f", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> PieceInfo(SimplePiece.FU, Player.SENTE, false))),
-        SavedTransition("3c3d", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> PieceInfo(SimplePiece.FU, Player.SENTE, false)) - posToKey(Position(3,3)) + (posToKey(Position(3,4)) -> PieceInfo(SimplePiece.FU, Player.GOTE, false))),
-        SavedTransition("2h7h", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> PieceInfo(SimplePiece.FU, Player.SENTE, false)) - posToKey(Position(3,3)) + (posToKey(Position(3,4)) -> PieceInfo(SimplePiece.FU, Player.GOTE, false)) - posToKey(Position(2,8)) + (posToKey(Position(7,8)) -> PieceInfo(SimplePiece.KA, Player.SENTE, false)))
+        SavedTransition("7g7f", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> CorePieceInfo(SimplePiece.FU, Player.SENTE, false))),
+        SavedTransition("3c3d", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> CorePieceInfo(SimplePiece.FU, Player.SENTE, false)) - posToKey(Position(3,3)) + (posToKey(Position(3,4)) -> CorePieceInfo(SimplePiece.FU, Player.GOTE, false))),
+        SavedTransition("2h7h", sampleBoardSetupMidGame - posToKey(Position(7,7)) + (posToKey(Position(7,6)) -> CorePieceInfo(SimplePiece.FU, Player.SENTE, false)) - posToKey(Position(3,3)) + (posToKey(Position(3,4)) -> CorePieceInfo(SimplePiece.FU, Player.GOTE, false)) - posToKey(Position(2,8)) + (posToKey(Position(7,8)) -> CorePieceInfo(SimplePiece.KA, Player.SENTE, false)))
     )
     val originalGameState = GameState(
-      boardSetup = sampleBoardSetupMidGame, // This is now Map[String, PieceInfo]
+      boardSetup = sampleBoardSetupMidGame, // This is now Map[String, CorePieceInfo]
       currentTurn = Player.GOTE,
       capturedPiecesPlayer1 = List(SimplePiece.FU, SimplePiece.FU, SimplePiece.KY),
       capturedPiecesPlayer2 = List(SimplePiece.GI),
@@ -121,7 +120,7 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
         loadedTrans.move shouldEqual origTrans.move
         loadedTrans.boardStateAfterMove.keys should contain theSameElementsAs origTrans.boardStateAfterMove.keys
         origTrans.boardStateAfterMove.keys.foreach { k =>
-            // Assuming PieceInfo has a sensible equals method or is a case class
+            // Assuming CorePieceInfo has a sensible equals method or is a case class
             loadedTrans.boardStateAfterMove(k) shouldEqual origTrans.boardStateAfterMove(k)
         }
     }
@@ -130,7 +129,7 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
 
   it should "save and load a game state with empty history" in withTempFile { filePath =>
     val originalGameState = GameState(
-      boardSetup = sampleBoardSetup, // This is now Map[String, PieceInfo]
+      boardSetup = sampleBoardSetup, // This is now Map[String, CorePieceInfo]
       currentTurn = Player.SENTE,
       capturedPiecesPlayer1 = List(SimplePiece.KI),
       capturedPiecesPlayer2 = Nil,
@@ -148,7 +147,7 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
   it should "save and load with captured pieces for both players" in withTempFile { filePath =>
     // King on 5,5
     val originalGameState = GameState(
-      boardSetup = Map(posToKey(Position(5,5)) -> PieceInfo(SimplePiece.OU, Player.SENTE, false)), // Sente King
+      boardSetup = Map(posToKey(Position(5,5)) -> CorePieceInfo(SimplePiece.OU, Player.SENTE, false)), // Sente King
       currentTurn = Player.GOTE,
       capturedPiecesPlayer1 = List(SimplePiece.HI, SimplePiece.KA, SimplePiece.FU, SimplePiece.FU),
       capturedPiecesPlayer2 = List(SimplePiece.KI, SimplePiece.GI, SimplePiece.KE, SimplePiece.KY),

--- a/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Console.scala
+++ b/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Console.scala
@@ -37,13 +37,22 @@ object Console extends App with Shogi {
 
     def read(state: State): Transition = {
       val inputLine = scala.Console.in.readLine
-      val routeRegex(a, b, c, d, e) = inputLine
-      // Board.humanReadableToPoint converts the 1-indexed (file, rank) from human input
-      // to the 0-indexed internal representation used by the Board.
-      val oldPos = Board.humanReadableToPoint(a.toInt, b.toInt)
-      val newPos = Board.humanReadableToPoint(c.toInt, d.toInt)
-      // Removed debug println for promotion flag 'e'
-      Transition(oldPos, newPos, e != null && e == "+", board.pieceOnBoardNotEmpty(newPos))
+      routeRegex.findFirstMatchIn(inputLine) match {
+        case Some(m) =>
+          val a = m.group(1)
+          val b = m.group(2)
+          val c = m.group(3)
+          val d = m.group(4)
+          val e = m.group(5) // This can be null if the '+' is not present
+
+          // Board.humanReadableToPoint converts the 1-indexed (file, rank) from human input
+          // to the 0-indexed internal representation used by the Board.
+          val oldPos = Board.humanReadableToPoint(a.toInt, b.toInt)
+          val newPos = Board.humanReadableToPoint(c.toInt, d.toInt)
+          Transition(oldPos, newPos, e != null && e == "+", board.pieceOnBoardNotEmpty(newPos))
+        case None =>
+          throw new IllegalArgumentException("Invalid command format. Please use (file,rank)(file,rank)[+].")
+      }
     }
   }
 
@@ -105,19 +114,27 @@ object Console extends App with Shogi {
 
   /** Called when an error occurs during input parsing or game processing. */
   override def onError(e: Exception): Unit = {
-    println(s"\nAn error occurred: ${e.getMessage}")
-    println("Could not parse your command or an internal error occurred.")
-    println("Retry with a valid move? (Y/N) or show stack trace and exit (X)")
-    scala.Console.in.readLine().trim().toUpperCase() match {
-      case "N" =>
+    e match {
+      case _: java.util.NoSuchElementException | _: java.io.EOFException =>
+        println("\nInput stream ended unexpectedly (e.g., Ctrl+D). This usually means no more input can be read.")
+        println("This can happen if the program is expecting input but the source is closed.")
         println("Exiting game.")
-        sys.exit
-      case "X" =>
-        e.printStackTrace()
-        println("Exiting game due to error.")
-        sys.exit
-      case _ => // Default to retry
-        println("Please try your move again.")
+        sys.exit(1)
+      case _ =>
+        println(s"\nAn error occurred: ${e.getMessage}")
+        println("Could not parse your command or an internal error occurred.")
+        println("Retry with a valid move? (Y/N) or show stack trace and exit (X)")
+        scala.Console.in.readLine().trim().toUpperCase() match {
+          case "N" =>
+            println("Exiting game.")
+            sys.exit
+          case "X" =>
+            e.printStackTrace()
+            println("Exiting game due to error.")
+            sys.exit
+          case _ => // Default to retry
+            println("Please try your move again.")
+        }
     }
   }
 

--- a/src/web/src/main/scala/jp/sndyuk/shogi/web/ShogiWebApp.scala
+++ b/src/web/src/main/scala/jp/sndyuk/shogi/web/ShogiWebApp.scala
@@ -5,7 +5,6 @@ import org.scalatra._
 // GameState, Position, ShogiGameService, SimplePiece are used.
 // SimpleTransition type will be fully qualified. Its JSON formatter is imported explicitly.
 import jp.sndyuk.shogi.core.{GameState, Position, ShogiGameService, SimplePiece}
-import jp.sndyuk.shogi.core.SimpleTransition.transitionFormat // Explicitly import the formatter
 import play.api.libs.json.{Json, Format, JsValue, Writes} // Play JSON imports
 
 // --- JSON Case Classes for API Requests ---


### PR DESCRIPTION
… various compilation errors.

This commit addresses several issues:

1.  **Console Error Handling:**
    *   I modified `Console.onError` to catch `NoSuchElementException` and `EOFException` during input reading. In such cases, the application now prints a message and exits, preventing potential infinite loops if the input stream is closed or ends unexpectedly.
    *   I refined `Console.commandReader.read` to use safer regex matching (`findFirstMatchIn`). If the input format is invalid, it now throws an `IllegalArgumentException` instead of a `MatchError`, providing clearer error information to be handled by `onError`.

2.  **ShogiGameService Bug:**
    *   I fixed a compilation error in `ShogiGameService.suggestMove` where it was incorrectly trying to access `coreTrans.piece`. The method now correctly retrieves the moving piece from the board state (`currentBoardCopy.piece(coreTrans.oldPos, turnForAI)`).

3.  **Build/Test Compilation Errors:**
    *   `ShogiWebApp.scala`: I removed an unused import (`jp.sndyuk.shogi.core.SimpleTransition.transitionFormat`).
    *   `GameSaverSpec.scala`:
        *   I aliased the `jp.sndyuk.shogi.core.PieceInfo` import to `CorePieceInfo` to resolve a hiding conflict.
        *   I removed an unused import (`jp.sndyuk.shogi.core.SimplePiece.SimplePieceType`).

I'm continuing to work on fixing further compilation errors in other test files (`ShogiGameServiceSpec.scala` and `KifuExporterSpec.scala`) to get the test suite fully passing.