### PR TITLE
Fix typo in Board.scala

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/Board.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/Board.scala
@@ -363,7 +363,7 @@ case class Board(squares: Squares = Squares(), val capturedPieces: CapturedPiece
     if (freeze) throw new IllegalStateException
     val pieceOldPos = pieceOnBoardNotEmpty(newPos)
     if (!move(oldPos, newPos, state.turn, validation, nari)) {
-      throw new IllegalStateException(s"Cound not move $oldPos to $newPos, Turn: ${state.turn}")
+      throw new IllegalStateException(s"Could not move $oldPos to $newPos, Turn: ${state.turn}")
     }
     State(Transition(oldPos, newPos, nari, pieceOldPos) :: state.history, state.turn.change)
   }


### PR DESCRIPTION
## Summary
- correct typo "Cound" -> "Could" in Board exception message

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_6840142875a48323a03b9c3d89d51766