### PR TITLE
Enhance move checking and repetition logic

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/BitSet.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/BitSet.scala
@@ -20,25 +20,33 @@ case class BitSet(val length: Int)(private val bits: Array[Long] = Array.fill(le
     cleared | shifted
   }
 
+  private val capacity = bits.length * 64
+
+  @inline private def validateIndex(i: Int): Unit = {
+    require(i >= 0 && i + span <= capacity,
+      s"BitSet index $i out of bounds for capacity $capacity")
+    assert((i % 64) + BitSet.span <= 64,
+      s"BitSet index $i (local ${i % 64}) too high for span ${BitSet.span}")
+  }
+
   def setInt(updates: Int, index: Int): Unit = {
-    assert((index % 64) + BitSet.span <= 64, s"BitSet.setInt called with global index ${index} (local index ${index % 64}) which is too high for span ${BitSet.span} within a single Long.")
-    // assert((index % 64 + span) < 64, index) // overflow check
+    validateIndex(index)
     bits(index / 64) = updateBits(bits(index / 64), updates, index % 64)
   }
 
   def value(index: Int): Int = {
+    validateIndex(index)
     (bits(index / 64) >>> (64 - (index % 64)) & 1).toInt
   }
 
   def intValue(i: Int): Int = {
-    assert((i % 64) + BitSet.span <= 64, s"BitSet.intValue called with global index ${i} (local index ${i % 64}) which is too high for span ${BitSet.span} within a single Long.")
-    // assert((i % 64 + span) < 64) // overflow check
+    validateIndex(i)
     val l = bits(i / 64)
     ((l >>> (64 - ((i % 64) + span))) & ((1 << span) - 1)).toInt
   }
 
   def replaceIntValue(updates: Long, i: Int): Int = {
-    assert((i % 64) + BitSet.span <= 64, s"BitSet.replaceIntValue called with global index ${i} (local index ${i % 64}) which is too high for span ${BitSet.span} within a single Long.")
+    validateIndex(i)
     val l = bits(i / 64)
     val index = i % 64
     val mask = masks(index)

--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/Board.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/Board.scala
@@ -106,9 +106,13 @@ private[core] case class Squares(private[core] val bits: BitSet = BitSet(9 * 9 *
   // (rowIndex, columnIndex)
   def find(piece: Piece): Option[Point] = allPoints.find(get(_) == piece)
 
-  def allPieces(turn: Turn): List[Block] = allPoints.foldLeft(List[Block]()) { (xs, point) =>
-    val piece = get(point)
-    if (▲△(piece, turn)) Block(point, piece) :: xs else xs
+  def allPieces(turn: Turn): List[Block] = {
+    val builder = List.newBuilder[Block]
+    allPoints.foreach { point =>
+      val piece = get(point)
+      if (▲△(piece, turn)) builder += Block(point, piece)
+    }
+    builder.result()
   }
 
   private class EmptyPointIterator() extends Iterator[Point] {

--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/Rule.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/Rule.scala
@@ -165,39 +165,54 @@ object Rule {
   // 無限に移動可能
   val ∞ = true
 
-  def movableScopes(piece: Piece): List[Scope] = {
-    piece match {
-      case ▲.OU => List((-1, 0, false), (-1, 1, false), (0, 1, false), (1, 1, false), (1, 0, false), (1, -1, false), (0, -1, false), (-1, -1, false))
-      case ▲.FU => List((-1, 0, false))
-      case ▲.KI => List((1, 0, false), (0, 1, false), (-1, 1, false), (-1, 0, false), (-1, -1, false), (0, -1, false))
-      case ▲.GI => List((-1, 0, false), (-1, 1, false), (1, 1, false), (1, -1, false), (-1, -1, false))
-      case ▲.HI => List((1, 0, true), (0, 1, true), (-1, 0, true), (0, -1, true))
-      case ▲.KA => List((1, 1, true), (-1, 1, true), (-1, -1, true), (1, -1, true))
-      case ▲.KE => List((-2, 1, false), (-2, -1, false))
-      case ▲.KY => List((-1, 0, true))
-      case ▲.TO => movableScopes(▲.KI)
-      case ▲.NG => movableScopes(▲.KI)
-      case ▲.RY => movableScopes(▲.OU) ::: movableScopes(▲.HI)
-      case ▲.UM => movableScopes(▲.OU) ::: movableScopes(▲.KA)
-      case ▲.NK => movableScopes(▲.KI)
-      case ▲.NY => movableScopes(▲.KI)
+  // Pre-computed movement scopes for each piece to avoid repeated List allocations
+  private val scopesSenteOU = List((-1, 0, false), (-1, 1, false), (0, 1, false), (1, 1, false), (1, 0, false), (1, -1, false), (0, -1, false), (-1, -1, false))
+  private val scopesSenteFU = List((-1, 0, false))
+  private val scopesSenteKI = List((1, 0, false), (0, 1, false), (-1, 1, false), (-1, 0, false), (-1, -1, false), (0, -1, false))
+  private val scopesSenteGI = List((-1, 0, false), (-1, 1, false), (1, 1, false), (1, -1, false), (-1, -1, false))
+  private val scopesSenteHI = List((1, 0, true), (0, 1, true), (-1, 0, true), (0, -1, true))
+  private val scopesSenteKA = List((1, 1, true), (-1, 1, true), (-1, -1, true), (1, -1, true))
+  private val scopesSenteKE = List((-2, 1, false), (-2, -1, false))
+  private val scopesSenteKY = List((-1, 0, true))
+  private val scopesGoteOU  = List((1, 0, false), (1, 1, false), (0, 1, false), (-1, 1, false), (-1, 0, false), (-1, -1, false), (0, -1, false), (1, -1, false))
+  private val scopesGoteFU  = List((1, 0, false))
+  private val scopesGoteKI  = List((1, 0, false), (1, 1, false), (0, 1, false), (-1, 0, false), (0, -1, false), (1, -1, false))
+  private val scopesGoteGI  = List((1, 0, false), (1, 1, false), (-1, 1, false), (-1, -1, false), (1, -1, false))
+  private val scopesGoteHI  = scopesSenteHI
+  private val scopesGoteKA  = scopesSenteKA
+  private val scopesGoteKE  = List((2, 1, false), (2, -1, false))
+  private val scopesGoteKY  = List((1, 0, true))
 
-      case ❏ => Nil
-      case △.OU => List((1, 0, false), (1, 1, false), (0, 1, false), (-1, 1, false), (-1, 0, false), (-1, -1, false), (0, -1, false), (1, -1, false))
-      case △.FU => List((1, 0, false))
-      case △.KI => List((1, 0, false), (1, 1, false), (0, 1, false), (-1, 0, false), (0, -1, false), (1, -1, false))
-      case △.GI => List((1, 0, false), (1, 1, false), (-1, 1, false), (-1, -1, false), (1, -1, false))
-      case △.HI => List((1, 0, true), (0, 1, true), (-1, 0, true), (0, -1, true))
-      case △.KA => List((1, 1, true), (-1, 1, true), (-1, -1, true), (1, -1, true))
-      case △.KE => List((2, 1, false), (2, -1, false))
-      case △.KY => List((1, 0, true))
-      case △.TO => movableScopes(△.KI)
-      case △.NG => movableScopes(△.KI)
-      case △.RY => movableScopes(△.OU) ::: movableScopes(△.HI)
-      case △.UM => movableScopes(△.OU) ::: movableScopes(△.KA)
-      case △.NK => movableScopes(△.KI)
-      case △.NY => movableScopes(△.KI)
-    }
+  // Promoted pieces reuse existing base piece scopes
+  private val scopesSentePromotedKI = scopesSenteKI
+  private val scopesGotePromotedKI  = scopesGoteKI
+  private val scopesPromotedOU_HI = scopesSenteOU ::: scopesSenteHI
+  private val scopesPromotedOU_KA = scopesSenteOU ::: scopesSenteKA
+
+  def movableScopes(piece: Piece): List[Scope] = piece match {
+    case ▲.OU => scopesSenteOU
+    case ▲.FU => scopesSenteFU
+    case ▲.KI => scopesSenteKI
+    case ▲.GI => scopesSenteGI
+    case ▲.HI => scopesSenteHI
+    case ▲.KA => scopesSenteKA
+    case ▲.KE => scopesSenteKE
+    case ▲.KY => scopesSenteKY
+    case ▲.TO | ▲.NG | ▲.NK | ▲.NY => scopesSentePromotedKI
+    case ▲.RY => scopesPromotedOU_HI
+    case ▲.UM => scopesPromotedOU_KA
+    case ❏    => Nil
+    case △.OU => scopesGoteOU
+    case △.FU => scopesGoteFU
+    case △.KI => scopesGoteKI
+    case △.GI => scopesGoteGI
+    case △.HI => scopesGoteHI
+    case △.KA => scopesGoteKA
+    case △.KE => scopesGoteKE
+    case △.KY => scopesGoteKY
+    case △.TO | △.NG | △.NK | △.NY => scopesGotePromotedKI
+    case △.RY => scopesPromotedOU_HI
+    case △.UM => scopesPromotedOU_KA
   }
 
   private val _0_8 = (0 to 8)
@@ -218,7 +233,12 @@ object Rule {
    *  千日手判定
    */
   def isThreefoldRepetition(currentBoardStateDigest: GameStateDigest, historyOfDigests: Seq[GameStateDigest]): Boolean = {
-    historyOfDigests.count(_ == currentBoardStateDigest) >= 3
+    var cnt = 0
+    val it = historyOfDigests.iterator
+    while (it.hasNext && cnt < 3) {
+      if (it.next() == currentBoardStateDigest) cnt += 1
+    }
+    cnt >= 3
   }
 
   /**
@@ -243,32 +263,14 @@ object Rule {
    * @return True if playerWhoseKingIsChecked's King is under attack, false otherwise.
    */
   def isInCheck(board: Board, playerWhoseKingIsChecked: Turn): Boolean = {
-    // 1. Find the King of 'playerWhoseKingIsChecked'
     val kingPiece = Piece.convert(Piece.◯.OU, playerWhoseKingIsChecked)
     board.squares.find(kingPiece) match {
-      case None =>
-        // King is not on the board, so it cannot be in check from an on-board piece.
-        // This scenario implies the game might have already ended or is in an invalid state.
-        false
+      case None => false
       case Some(kingPos) =>
-        // 2. Check if any of the opponent's pieces can attack the King's position.
         val opponentTurn = playerWhoseKingIsChecked.change
-
-        for (y <- 0 to 8; x <- 0 to 8) {
-          val currentPiecePoint = Point(y,x)
-          val currentPiece = board.squares.get(currentPiecePoint)
-
-          // If it's an opponent's piece
-          if (currentPiece != Piece.❏ && Piece.▲△(currentPiece, opponentTurn)) {
-            // Generate its moves (non-promoting moves are sufficient for checking attack)
-            val movesForThisOpponentPiece = generateMovablePoints(board, currentPiecePoint, currentPiece, opponentTurn, false)
-            if (movesForThisOpponentPiece.exists { case (newPos, _) => newPos == kingPos }) {
-              return true // King is attacked by this piece
-            }
-          }
+        board.squares.allPieces(opponentTurn).exists { block =>
+          canMove(board, block.piece, block.point, kingPos, opponentTurn)
         }
-        // No opponent piece found that can attack the King's position
-        false
     }
   }
 }

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/BoardInternalsSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/BoardInternalsSpec.scala
@@ -124,4 +124,27 @@ class BitSetSpec extends AnyFlatSpec with Matchers { // Restored name
     bs.intValue(spanValue) shouldBe 10     // Middle value updated
     bs.intValue(spanValue * 2) shouldBe 3  // Third value unchanged
   }
+
+  "BitSet" should "throw on out of range index" in {
+    val bs = new BitSet(20)()
+    assertThrows[IllegalArgumentException] {
+      bs.setInt(1, 60) // 60 + span(5) > capacity 64
+    }
+  }
+
+  "Squares.allPieces" should "list pieces for each player" in {
+    val board = Board()
+    val sente = board.squares.allPieces(PlayerA)
+    val gote  = board.squares.allPieces(PlayerB)
+    sente.length shouldBe 20
+    gote.length  shouldBe 20
+    sente.forall(b => Piece.▲(b.piece)) shouldBe true
+    gote.forall(b => Piece.△(b.piece))  shouldBe true
+  }
+
+  "Squares.allEmptyPoints" should "return all empty board locations" in {
+    val board = Board()
+    val empties = board.squares.allEmptyPoints().toList
+    empties.length shouldBe 41
+  }
 }

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/RuleSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/RuleSpec.scala
@@ -614,4 +614,32 @@ class RuleSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
     // Assert that no drop moves are generated for the King
     dropMoves shouldBe empty
   }
+
+  "Rule.movableScopes" should "return cached lists to avoid allocations" in {
+    val first = Rule.movableScopes(Piece.▲.FU)
+    val second = Rule.movableScopes(Piece.▲.FU)
+    (first eq second) shouldBe true
+  }
+
+  "Rule.isInCheck" should "detect when a king is attacked" in {
+    val kingPos = Point(4,4)
+    val rookPos = Point(4,0)
+    val board = createBoardWithHands(boardPieces = Seq(
+      (Piece.▲.OU, kingPos),
+      (Piece.△.HI, rookPos)
+    ))
+    Rule.isInCheck(board, PlayerA) shouldBe true
+  }
+
+  it should "return false when pieces block the attack" in {
+    val kingPos = Point(4,4)
+    val rookPos = Point(4,0)
+    val blocker = Point(4,2)
+    val board = createBoardWithHands(boardPieces = Seq(
+      (Piece.▲.OU, kingPos),
+      (Piece.△.HI, rookPos),
+      (Piece.▲.FU, blocker)
+    ))
+    Rule.isInCheck(board, PlayerA) shouldBe false
+  }
 }


### PR DESCRIPTION
## Summary
- optimize `isThreefoldRepetition` with early exit counting
- rewrite `isInCheck` using `allPieces` and `canMove`
- add tests for new `isInCheck` scenarios

## Testing
- `sbt 'testOnly jp.sndyuk.shogi.core.RuleSpec'`


------
https://chatgpt.com/codex/tasks/task_e_6840395f72308323b44060e704b91a69