### PR TITLE
Add AlphaBetaAI_V5 with null move pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Shogi library for Scala.
 ### Features
 - **Core Shogi Logic:** Full implementation of Shogi rules, including board representation, piece movement, drops, promotion, check, and mate detection.
 - **AI Opponent:** Play against a built-in AI.
+- **Advanced AI Version 5:** Utilizes a transposition table and Null Move Pruning for stronger play.
 - **Kifu Parsing:** Support for reading game records in CSA and KI2 formats.
 - **Player Management:** Code structure for managing human and AI players.
 - **Sample GUI Application:** Includes a basic graphical interface to demonstrate library usage.

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V5.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V5.scala
@@ -1,0 +1,56 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{State, Board, Turn, Transition, ID}
+
+/**
+ * AlphaBetaAI_V5 adds Null Move Pruning on top of the V4 transposition table
+ * search, allowing deeper searches with better pruning.
+ */
+class AlphaBetaAI_V5(val name: String = "AlphaBetaAI_V5", searchDepth: Int) extends ShogiAI {
+
+  private val MATE_SCORE_GUARD = 100
+
+  override def findBestMove(
+      state: State,
+      board: Board,
+      turn: Turn,
+      currentSearchDepth: Int
+  ): (Option[Transition], Long) = {
+    var bestMove: Option[Transition] = None
+    var nodesVisitedTotal: Long = 0L
+
+    TranspositionTable.clear()
+
+    var depth = 1
+    while (depth <= currentSearchDepth) {
+      val alpha = Int.MinValue + MATE_SCORE_GUARD
+      val beta = Int.MaxValue - MATE_SCORE_GUARD
+      val initialBoardID = ID(board)
+
+      val (_, moveOpt, nodesVisited) = AlphaBetaSearchNMP.search(
+        currentState = state,
+        currentBoard = board,
+        currentBoardID = initialBoardID,
+        gamePathHistoryIDs = Nil,
+        depth = depth,
+        alpha = alpha,
+        beta = beta,
+        maximizingPlayer = true,
+        rootPlayerTurn = turn,
+        evalFunc = EvaluationV2.evaluate,
+        transpositionTable = TranspositionTable
+      )
+
+      nodesVisitedTotal += nodesVisited
+      if (moveOpt.isDefined) {
+        bestMove = moveOpt
+      }
+
+      depth += 1
+    }
+
+    (bestMove, nodesVisitedTotal)
+  }
+
+  override def toString: String = s"$name(depth=$searchDepth)"
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMP.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMP.scala
@@ -1,0 +1,134 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{State, Board, Turn, Transition, ID, PlayerA, Rule}
+import jp.sndyuk.shogi.player.Utils
+
+/**
+ * AlphaBeta search with transposition table and Null Move Pruning.
+ */
+object AlphaBetaSearchNMP {
+  private val MATE_SCORE = 1000000
+  private val NULL_REDUCTION = 2
+
+  def search(
+      currentState: State,
+      currentBoard: Board,
+      currentBoardID: ID,
+      gamePathHistoryIDs: List[ID],
+      depth: Int,
+      alpha: Int,
+      beta: Int,
+      maximizingPlayer: Boolean,
+      rootPlayerTurn: Turn,
+      evalFunc: (Board, Turn) => Int,
+      transpositionTable: TranspositionTable.type
+  ): (Int, Option[Transition], Long) = {
+
+    var nodesVisited: Long = 1L
+
+    val ttKey = currentBoardID.hashLong ^ (if (rootPlayerTurn == PlayerA) 0L else 1L)
+    transpositionTable.get(ttKey, depth) match {
+      case Some(entry) => return (entry.value, entry.bestMove, nodesVisited)
+      case None        => // continue
+    }
+
+    if (gamePathHistoryIDs.count(_ == currentBoardID) >= 2) {
+      return (0, None, nodesVisited)
+    }
+
+    if (depth == 0) {
+      val score = evalFunc(currentBoard, rootPlayerTurn)
+      transpositionTable.put(ttKey, score, depth, None)
+      return (score, None, nodesVisited)
+    }
+
+    val legalMoves = Utils.plans(currentBoard, currentState).toList
+    if (legalMoves.isEmpty) {
+      val score = if (currentState.turn == rootPlayerTurn) {
+        -MATE_SCORE - depth
+      } else {
+        MATE_SCORE + depth
+      }
+      transpositionTable.put(ttKey, score, depth, None)
+      return (score, None, nodesVisited)
+    }
+
+    // Null Move Pruning
+    if (depth >= NULL_REDUCTION + 1 && !Rule.isInCheck(currentBoard, currentState.turn)) {
+      val nullState = currentState.copy(turn = currentState.turn.change)
+      val (nullEval, _, nullNodes) = search(
+        nullState,
+        currentBoard,
+        currentBoardID,
+        currentBoardID :: gamePathHistoryIDs,
+        depth - 1 - NULL_REDUCTION,
+        alpha,
+        beta,
+        !maximizingPlayer,
+        rootPlayerTurn,
+        evalFunc,
+        transpositionTable
+      )
+      nodesVisited += nullNodes
+      if (maximizingPlayer && nullEval >= beta) {
+        transpositionTable.put(ttKey, nullEval, depth, None)
+        return (nullEval, None, nodesVisited)
+      } else if (!maximizingPlayer && nullEval <= alpha) {
+        transpositionTable.put(ttKey, nullEval, depth, None)
+        return (nullEval, None, nodesVisited)
+      }
+    }
+
+    if (maximizingPlayer) {
+      var bestEval = Int.MinValue
+      var bestMove: Option[Transition] = None
+      var a = alpha
+      for (move <- legalMoves) {
+        val tempBoard = currentBoard.copy()
+        val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
+        val nextID = ID(tempBoard)
+        val (eval, _, childNodes) = search(nextState, tempBoard, nextID,
+          currentBoardID :: gamePathHistoryIDs,
+          depth - 1, a, beta, maximizingPlayer = false,
+          rootPlayerTurn, evalFunc, transpositionTable)
+        nodesVisited += childNodes
+        if (eval > bestEval) {
+          bestEval = eval
+          bestMove = Some(move)
+        }
+        a = math.max(a, eval)
+        if (beta <= a) {
+          transpositionTable.put(ttKey, bestEval, depth, bestMove)
+          return (bestEval, bestMove, nodesVisited)
+        }
+      }
+      transpositionTable.put(ttKey, bestEval, depth, bestMove)
+      (bestEval, bestMove, nodesVisited)
+    } else {
+      var bestEval = Int.MaxValue
+      var bestMove: Option[Transition] = None
+      var b = beta
+      for (move <- legalMoves) {
+        val tempBoard = currentBoard.copy()
+        val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
+        val nextID = ID(tempBoard)
+        val (eval, _, childNodes) = search(nextState, tempBoard, nextID,
+          currentBoardID :: gamePathHistoryIDs,
+          depth - 1, alpha, b, maximizingPlayer = true,
+          rootPlayerTurn, evalFunc, transpositionTable)
+        nodesVisited += childNodes
+        if (eval < bestEval) {
+          bestEval = eval
+          bestMove = Some(move)
+        }
+        b = math.min(b, eval)
+        if (b <= alpha) {
+          transpositionTable.put(ttKey, bestEval, depth, bestMove)
+          return (bestEval, bestMove, nodesVisited)
+        }
+      }
+      transpositionTable.put(ttKey, bestEval, depth, bestMove)
+      (bestEval, bestMove, nodesVisited)
+    }
+  }
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/TranspositionTable.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/TranspositionTable.scala
@@ -4,7 +4,7 @@ import jp.sndyuk.shogi.core.Transition
 
 import scala.collection.mutable
 
-/** Simple transposition table used by AlphaBetaAI_V4 to cache evaluated states. */
+/** Simple transposition table used by AlphaBetaAI_V4/V5 to cache evaluated states. */
 object TranspositionTable {
   case class Entry(value: Int, depth: Int, bestMove: Option[Transition])
 

--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
@@ -2,7 +2,7 @@ package jp.sndyuk.shogi.core
 
 import jp.sndyuk.shogi.core.Player.Player
 import jp.sndyuk.shogi.core.SimplePiece.SimplePieceType
-import jp.sndyuk.shogi.ai.{ShogiAI, AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V3, AlphaBetaAI_V4}
+import jp.sndyuk.shogi.ai.{ShogiAI, AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V3, AlphaBetaAI_V4, AlphaBetaAI_V5}
 import play.api.libs.json.{Json, JsValue, JsNumber, JsString, JsBoolean}
 
 object AIProvider {
@@ -12,6 +12,7 @@ object AIProvider {
       case "v2" => Some(new AlphaBetaAI_V2("AlphaBetaAI_V2", searchDepth))
       case "v3" => Some(new AlphaBetaAI_V3("AlphaBetaAI_V3", searchDepth))
       case "v4" => Some(new AlphaBetaAI_V4("AlphaBetaAI_V4", searchDepth))
+      case "v5" => Some(new AlphaBetaAI_V5("AlphaBetaAI_V5", searchDepth))
       case _    => None
     }
   }
@@ -33,7 +34,7 @@ class ShogiGameService {
 
 
   // Initialize a new game upon service creation using default parameters
-  startNewGame(gameMode = "hvh", aiType = "v4", aiSearchDepth = 3)
+  startNewGame(gameMode = "hvh", aiType = "v5", aiSearchDepth = 3)
 
   def startNewGame(
     initialBoardSetup: Option[Map[String, PieceInfo]] = None, // Updated type
@@ -41,7 +42,7 @@ class ShogiGameService {
     initialGoteCaptured: List[SimplePieceType] = Nil,
     firstPlayer: Player = Player.SENTE,
     gameMode: String = "hvh",
-    aiType: String = "v4",
+    aiType: String = "v5",
     aiSearchDepth: Int = 3
   ): GameState = {
     // Store initial parameters for potential future use (e.g. robust history replay)

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/ShogiGameServiceSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/ShogiGameServiceSpec.scala
@@ -2,7 +2,7 @@ package jp.sndyuk.shogi.core
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import jp.sndyuk.shogi.ai.{AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V4}
+import jp.sndyuk.shogi.ai.{AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V4, AlphaBetaAI_V5}
 
 
 class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
@@ -36,6 +36,16 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.gameMode shouldBe "hva_sente"
     service.aiOpponent shouldBe defined
     service.aiOpponent.get shouldBe an [AlphaBetaAI_V4]
+    service.aiSearchDepth shouldBe 2
+  }
+
+  it should "start a game using the new v5 AI" in {
+    val service = new ShogiGameService()
+    service.startNewGame(gameMode = "hva_sente", aiType = "v5", aiSearchDepth = 2)
+
+    service.gameMode shouldBe "hva_sente"
+    service.aiOpponent shouldBe defined
+    service.aiOpponent.get shouldBe an [AlphaBetaAI_V5]
     service.aiSearchDepth shouldBe 2
   }
 

--- a/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Console.scala
+++ b/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Console.scala
@@ -14,7 +14,7 @@ import jp.sndyuk.shogi.core.Transition
 import jp.sndyuk.shogi.player.CommandReader
 import jp.sndyuk.shogi.core.PlayerB // Gote (second player)
 // import jp.sndyuk.shogi.core.PlayerA // Sente (first player) - Unused import
-import jp.sndyuk.shogi.ai.{AlphaBetaAI_V4} // Use stronger AI implementation with TT
+import jp.sndyuk.shogi.ai.{AlphaBetaAI_V5} // Use strongest AI implementation with TT and NMP
 
 object Console extends App with Shogi {
 
@@ -67,8 +67,8 @@ object Console extends App with Shogi {
   // override val playerA: Player = new AIPlayer("AI_PlayerA (Sente)", PlayerA, new AlphaBetaAI_V1(name = "AI_A", searchDepth = 1), 1)
 
 
-  // Player B (Gote) is an AI player using the stronger AlphaBetaAI_V4.
-  override val playerB: Player = new AIPlayer("AI_PlayerB (Gote)", PlayerB, new AlphaBetaAI_V4(name = "AI_B", searchDepth = 2), 2)
+  // Player B (Gote) is an AI player using the stronger AlphaBetaAI_V5.
+  override val playerB: Player = new AIPlayer("AI_PlayerB (Gote)", PlayerB, new AlphaBetaAI_V5(name = "AI_B", searchDepth = 2), 2)
   // To make Player B a Human Player:
   // override val playerB: Player = new HumanPlayer("Human_PlayerB (Gote)", board, commandReader, true)
   // To use a different AI or search depth for Player B:

--- a/src/web/src/main/scala/jp/sndyuk/shogi/web/ShogiWebApp.scala
+++ b/src/web/src/main/scala/jp/sndyuk/shogi/web/ShogiWebApp.scala
@@ -76,7 +76,7 @@ class ShogiWebApp extends ScalatraServlet {
     val body = request.body
     if (body.trim.isEmpty) {
       // No body, start a default game
-      val newGameState = shogiGameService.startNewGame(gameMode = "hvh", aiType = "v4", aiSearchDepth = 3) // Default HVH
+      val newGameState = shogiGameService.startNewGame(gameMode = "hvh", aiType = "v5", aiSearchDepth = 3) // Default HVH
       Json.toJson(newGameState).toString()
     } else {
       // Body present, try to parse as NewGameRequest
@@ -89,7 +89,7 @@ class ShogiWebApp extends ScalatraServlet {
       jsonBody.validate[NewGameRequest].asOpt match {
         case Some(req) =>
           val gameMode = req.gameMode.getOrElse("hvh")
-          val aiType = req.aiType.getOrElse("v4")
+          val aiType = req.aiType.getOrElse("v5")
           val aiSearchDepth = req.aiSearchDepth.getOrElse(3)
 
           val newGameState = shogiGameService.startNewGame(
@@ -107,7 +107,7 @@ class ShogiWebApp extends ScalatraServlet {
 
   // GET /game/suggest_move
   get("/game/suggest_move") {
-    val aiTypeParam = params.get("aiType").getOrElse("v4")
+    val aiTypeParam = params.get("aiType").getOrElse("v5")
     val aiSearchDepthParam = params.getAs[Int]("aiSearchDepth").getOrElse(3)
 
     // This method shogiGameService.suggestMove(aiType, depth) needs to be implemented in ShogiGameService


### PR DESCRIPTION
## Summary
- add AlphaBetaSearchNMP implementing null move pruning with transposition table
- introduce AlphaBetaAI_V5 using the new search
- wire AI V5 into game service, console, and web app defaults
- update tests and README for new AI

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_68403c702d4083238d4afb5722aa7f9e