### PR TITLE
Fix killer move initialization

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMP.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMP.scala
@@ -23,18 +23,16 @@ object AlphaBetaSearchNMP {
     Piece.◯.KI -> 500,
     Piece.◯.KA -> 800,
     Piece.◯.HI -> 900,
-    Piece.◯.TO -> 550,
-    Piece.◯.NY -> 530,
-    Piece.◯.NK -> 530,
-    Piece.◯.NG -> 550,
-    Piece.◯.UM -> 1200,
-    Piece.◯.RY -> 1300,
     Piece.◯.OU -> Int.MaxValue
   ).withDefaultValue(0)
 
   def clearKillers(): Unit = {
-    java.util.Arrays.fill(killerMoves1.asInstanceOf[Array[AnyRef]], null)
-    java.util.Arrays.fill(killerMoves2.asInstanceOf[Array[AnyRef]], null)
+    var i = 0
+    while (i < MAX_DEPTH) {
+      killerMoves1(i) = None
+      killerMoves2(i) = None
+      i += 1
+    }
   }
 
   private def updateKillers(depth: Int, move: Transition): Unit = {


### PR DESCRIPTION
## Summary
- fix compile error by using only existing general piece constants
- ensure killer move arrays reset to `None` instead of null to avoid NPEs

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_684045296bc08323b5d9557193396135