### PR TITLE
Add AlphaBetaAI_V6 with quiescence search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Shogi library for Scala.
 - **Core Shogi Logic:** Full implementation of Shogi rules, including board representation, piece movement, drops, promotion, check, and mate detection.
 - **AI Opponent:** Play against a built-in AI.
 - **Advanced AI Version 5:** Utilizes a transposition table, Null Move Pruning, and killer move heuristics for stronger play.
+- **Advanced AI Version 6:** Adds quiescence search to V5's techniques for even deeper tactical strength.
 - **Kifu Parsing:** Support for reading game records in CSA and KI2 formats.
 - **Player Management:** Code structure for managing human and AI players.
 - **Sample GUI Application:** Includes a basic graphical interface to demonstrate library usage.

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V6.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V6.scala
@@ -1,0 +1,58 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{State, Board, Turn, Transition, ID}
+
+/**
+ * AlphaBetaAI_V6 builds on V5 by adding a quiescence search at leaf nodes
+ * of the Null Move Pruning search. This helps avoid the horizon effect
+ * and typically results in stronger play.
+ */
+class AlphaBetaAI_V6(val name: String = "AlphaBetaAI_V6", searchDepth: Int) extends ShogiAI {
+
+  private val MATE_SCORE_GUARD = 100
+
+  override def findBestMove(
+      state: State,
+      board: Board,
+      turn: Turn,
+      currentSearchDepth: Int
+  ): (Option[Transition], Long) = {
+    var bestMove: Option[Transition] = None
+    var nodesVisitedTotal: Long = 0L
+
+    TranspositionTable.clear()
+    AlphaBetaSearchNMPQ.clearKillers()
+
+    var depth = 1
+    while (depth <= currentSearchDepth) {
+      val alpha = Int.MinValue + MATE_SCORE_GUARD
+      val beta = Int.MaxValue - MATE_SCORE_GUARD
+      val initialBoardID = ID(board)
+
+      val (_, moveOpt, nodesVisited) = AlphaBetaSearchNMPQ.search(
+        currentState = state,
+        currentBoard = board,
+        currentBoardID = initialBoardID,
+        gamePathHistoryIDs = Nil,
+        depth = depth,
+        alpha = alpha,
+        beta = beta,
+        maximizingPlayer = true,
+        rootPlayerTurn = turn,
+        evalFunc = EvaluationV2.evaluate,
+        transpositionTable = TranspositionTable
+      )
+
+      nodesVisitedTotal += nodesVisited
+      if (moveOpt.isDefined) {
+        bestMove = moveOpt
+      }
+
+      depth += 1
+    }
+
+    (bestMove, nodesVisitedTotal)
+  }
+
+  override def toString: String = s"$name(depth=$searchDepth)"
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
@@ -1,0 +1,183 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{State, Board, Turn, Transition, ID, PlayerA, Rule, Piece}
+import jp.sndyuk.shogi.player.Utils
+
+/**
+ * AlphaBeta search with transposition table, Null Move Pruning,
+ * killer move heuristics and quiescence search at leaf nodes.
+ */
+object AlphaBetaSearchNMPQ {
+  private val MATE_SCORE = 1000000
+  private val NULL_REDUCTION = 2
+  private val MAX_DEPTH = 64
+
+  // Killer move heuristic: store up to two killer moves per depth
+  private val killerMoves1 = Array.fill[Option[Transition]](MAX_DEPTH)(None)
+  private val killerMoves2 = Array.fill[Option[Transition]](MAX_DEPTH)(None)
+
+  private val pieceOrderingValue: Map[Int, Int] = Map(
+    Piece.◯.FU -> 100,
+    Piece.◯.KY -> 300,
+    Piece.◯.KE -> 320,
+    Piece.◯.GI -> 450,
+    Piece.◯.KI -> 500,
+    Piece.◯.KA -> 800,
+    Piece.◯.HI -> 900,
+    Piece.◯.OU -> Int.MaxValue
+  ).withDefaultValue(0)
+
+  def clearKillers(): Unit = {
+    var i = 0
+    while (i < MAX_DEPTH) {
+      killerMoves1(i) = None
+      killerMoves2(i) = None
+      i += 1
+    }
+  }
+
+  private def updateKillers(depth: Int, move: Transition): Unit = {
+    if (!killerMoves1(depth).contains(move)) {
+      killerMoves2(depth) = killerMoves1(depth)
+      killerMoves1(depth) = Some(move)
+    }
+  }
+
+  def search(
+      currentState: State,
+      currentBoard: Board,
+      currentBoardID: ID,
+      gamePathHistoryIDs: List[ID],
+      depth: Int,
+      alpha: Int,
+      beta: Int,
+      maximizingPlayer: Boolean,
+      rootPlayerTurn: Turn,
+      evalFunc: (Board, Turn) => Int,
+      transpositionTable: TranspositionTable.type
+  ): (Int, Option[Transition], Long) = {
+
+    var nodesVisited: Long = 1L
+
+    val ttKey = currentBoardID.hashLong ^ (if (rootPlayerTurn == PlayerA) 0L else 1L)
+    val ttEntryOpt = transpositionTable.get(ttKey, depth)
+    ttEntryOpt match {
+      case Some(entry) if entry.depth >= depth => return (entry.value, entry.bestMove, nodesVisited)
+      case _ =>
+    }
+    val ttMove = ttEntryOpt.flatMap(_.bestMove)
+
+    if (gamePathHistoryIDs.count(_ == currentBoardID) >= 2) {
+      return (0, None, nodesVisited)
+    }
+
+    if (depth == 0) {
+      val (score, qNodes) = QuiescenceSearch.search(currentState, currentBoard, currentBoardID, alpha, beta, maximizingPlayer, rootPlayerTurn, evalFunc)
+      nodesVisited += qNodes - 1
+      transpositionTable.put(ttKey, score, depth, None)
+      return (score, None, nodesVisited)
+    }
+
+    val legalMovesRaw = Utils.plans(currentBoard, currentState).toList
+    val legalMoves = legalMovesRaw.sortBy { m =>
+      var score = 0
+      if (ttMove.contains(m)) score -= 2000
+      if (killerMoves1(depth).contains(m)) score -= 1500
+      if (killerMoves2(depth).contains(m)) score -= 1400
+      m.captured match {
+        case Some(pc) => score -= pieceOrderingValue(Piece.generalize(pc))
+        case None =>
+      }
+      score
+    }
+    if (legalMoves.isEmpty) {
+      val score = if (currentState.turn == rootPlayerTurn) {
+        -MATE_SCORE - depth
+      } else {
+        MATE_SCORE + depth
+      }
+      transpositionTable.put(ttKey, score, depth, None)
+      return (score, None, nodesVisited)
+    }
+
+    // Null Move Pruning
+    if (depth >= NULL_REDUCTION + 1 && !Rule.isInCheck(currentBoard, currentState.turn)) {
+      val nullState = currentState.copy(turn = currentState.turn.change)
+      val (nullEval, _, nullNodes) = search(
+        nullState,
+        currentBoard,
+        currentBoardID,
+        currentBoardID :: gamePathHistoryIDs,
+        depth - 1 - NULL_REDUCTION,
+        alpha,
+        beta,
+        !maximizingPlayer,
+        rootPlayerTurn,
+        evalFunc,
+        transpositionTable
+      )
+      nodesVisited += nullNodes
+      if (maximizingPlayer && nullEval >= beta) {
+        transpositionTable.put(ttKey, nullEval, depth, None)
+        return (nullEval, None, nodesVisited)
+      } else if (!maximizingPlayer && nullEval <= alpha) {
+        transpositionTable.put(ttKey, nullEval, depth, None)
+        return (nullEval, None, nodesVisited)
+      }
+    }
+
+    if (maximizingPlayer) {
+      var bestEval = Int.MinValue
+      var bestMove: Option[Transition] = None
+      var a = alpha
+      for (move <- legalMoves) {
+        val tempBoard = currentBoard.copy()
+        val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
+        val nextID = ID(tempBoard)
+        val (eval, _, childNodes) = search(nextState, tempBoard, nextID,
+          currentBoardID :: gamePathHistoryIDs,
+          depth - 1, a, beta, maximizingPlayer = false,
+          rootPlayerTurn, evalFunc, transpositionTable)
+        nodesVisited += childNodes
+        if (eval > bestEval) {
+          bestEval = eval
+          bestMove = Some(move)
+        }
+        a = math.max(a, eval)
+        if (beta <= a) {
+          updateKillers(depth, move)
+          transpositionTable.put(ttKey, bestEval, depth, bestMove)
+          return (bestEval, bestMove, nodesVisited)
+        }
+      }
+      transpositionTable.put(ttKey, bestEval, depth, bestMove)
+      (bestEval, bestMove, nodesVisited)
+    } else {
+      var bestEval = Int.MaxValue
+      var bestMove: Option[Transition] = None
+      var b = beta
+      for (move <- legalMoves) {
+        val tempBoard = currentBoard.copy()
+        val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
+        val nextID = ID(tempBoard)
+        val (eval, _, childNodes) = search(nextState, tempBoard, nextID,
+          currentBoardID :: gamePathHistoryIDs,
+          depth - 1, alpha, b, maximizingPlayer = true,
+          rootPlayerTurn, evalFunc, transpositionTable)
+        nodesVisited += childNodes
+        if (eval < bestEval) {
+          bestEval = eval
+          bestMove = Some(move)
+        }
+        b = math.min(b, eval)
+        if (b <= alpha) {
+          updateKillers(depth, move)
+          transpositionTable.put(ttKey, bestEval, depth, bestMove)
+          return (bestEval, bestMove, nodesVisited)
+        }
+      }
+      transpositionTable.put(ttKey, bestEval, depth, bestMove)
+      (bestEval, bestMove, nodesVisited)
+    }
+  }
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
@@ -1,0 +1,68 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{State, Board, Turn, ID}
+import jp.sndyuk.shogi.player.Utils
+
+/**
+ * Simple quiescence search exploring only capturing moves.
+ * Used by AlphaBetaAI_V6 to reduce the horizon effect.
+ */
+object QuiescenceSearch {
+  def search(
+      currentState: State,
+      currentBoard: Board,
+      currentBoardID: ID,
+      alpha: Int,
+      beta: Int,
+      maximizingPlayer: Boolean,
+      rootPlayerTurn: Turn,
+      evalFunc: (Board, Turn) => Int
+  ): (Int, Long) = {
+    var nodesVisited: Long = 1L
+
+    // Stand pat evaluation from the perspective of rootPlayerTurn
+    val standPat = evalFunc(currentBoard, rootPlayerTurn)
+    var a = alpha
+    var b = beta
+
+    if (maximizingPlayer) {
+      if (standPat > a) a = standPat
+      if (a >= b) return (standPat, nodesVisited)
+    } else {
+      if (standPat < b) b = standPat
+      if (b <= a) return (standPat, nodesVisited)
+    }
+
+    val captureMoves = Utils.plans(currentBoard, currentState).filter(_.captured.isDefined).toList
+
+    if (maximizingPlayer) {
+      var bestEval = standPat
+      var alphaVar = a
+      for (move <- captureMoves) {
+        val tempBoard = currentBoard.copy()
+        val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
+        val nextID = ID(tempBoard)
+        val (score, childNodes) = search(nextState, tempBoard, nextID, alphaVar, b, maximizingPlayer = false, rootPlayerTurn, evalFunc)
+        nodesVisited += childNodes
+        if (score > bestEval) bestEval = score
+        if (score > alphaVar) alphaVar = score
+        if (alphaVar >= b) return (bestEval, nodesVisited)
+      }
+      (bestEval, nodesVisited)
+    } else {
+      var bestEval = standPat
+      var betaVar = b
+      for (move <- captureMoves) {
+        val tempBoard = currentBoard.copy()
+        val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
+        val nextID = ID(tempBoard)
+        val (score, childNodes) = search(nextState, tempBoard, nextID, a, betaVar, maximizingPlayer = true, rootPlayerTurn, evalFunc)
+        nodesVisited += childNodes
+        if (score < bestEval) bestEval = score
+        if (score < betaVar) betaVar = score
+        if (betaVar <= a) return (bestEval, nodesVisited)
+      }
+      (bestEval, nodesVisited)
+    }
+  }
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
@@ -2,7 +2,7 @@ package jp.sndyuk.shogi.core
 
 import jp.sndyuk.shogi.core.Player.Player
 import jp.sndyuk.shogi.core.SimplePiece.SimplePieceType
-import jp.sndyuk.shogi.ai.{ShogiAI, AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V3, AlphaBetaAI_V4, AlphaBetaAI_V5}
+import jp.sndyuk.shogi.ai.{ShogiAI, AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V3, AlphaBetaAI_V4, AlphaBetaAI_V5, AlphaBetaAI_V6}
 import play.api.libs.json.{Json, JsValue, JsNumber, JsString, JsBoolean}
 
 object AIProvider {
@@ -13,6 +13,7 @@ object AIProvider {
       case "v3" => Some(new AlphaBetaAI_V3("AlphaBetaAI_V3", searchDepth))
       case "v4" => Some(new AlphaBetaAI_V4("AlphaBetaAI_V4", searchDepth))
       case "v5" => Some(new AlphaBetaAI_V5("AlphaBetaAI_V5", searchDepth))
+      case "v6" => Some(new AlphaBetaAI_V6("AlphaBetaAI_V6", searchDepth))
       case _    => None
     }
   }

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/ShogiGameServiceSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/ShogiGameServiceSpec.scala
@@ -2,7 +2,7 @@ package jp.sndyuk.shogi.core
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import jp.sndyuk.shogi.ai.{AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V4, AlphaBetaAI_V5}
+import jp.sndyuk.shogi.ai.{AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V4, AlphaBetaAI_V5, AlphaBetaAI_V6}
 
 
 class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
@@ -46,6 +46,16 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.gameMode shouldBe "hva_sente"
     service.aiOpponent shouldBe defined
     service.aiOpponent.get shouldBe an [AlphaBetaAI_V5]
+    service.aiSearchDepth shouldBe 2
+  }
+
+  it should "start a game using the new v6 AI" in {
+    val service = new ShogiGameService()
+    service.startNewGame(gameMode = "hva_sente", aiType = "v6", aiSearchDepth = 2)
+
+    service.gameMode shouldBe "hva_sente"
+    service.aiOpponent shouldBe defined
+    service.aiOpponent.get shouldBe an [AlphaBetaAI_V6]
     service.aiSearchDepth shouldBe 2
   }
 

--- a/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Console.scala
+++ b/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Console.scala
@@ -14,7 +14,7 @@ import jp.sndyuk.shogi.core.Transition
 import jp.sndyuk.shogi.player.CommandReader
 import jp.sndyuk.shogi.core.PlayerB // Gote (second player)
 // import jp.sndyuk.shogi.core.PlayerA // Sente (first player) - Unused import
-import jp.sndyuk.shogi.ai.{AlphaBetaAI_V5} // Use strongest AI implementation with TT and NMP
+import jp.sndyuk.shogi.ai.{AlphaBetaAI_V6} // Use strongest AI implementation with TT, NMP, and quiescence search
 
 object Console extends App with Shogi {
 
@@ -67,8 +67,8 @@ object Console extends App with Shogi {
   // override val playerA: Player = new AIPlayer("AI_PlayerA (Sente)", PlayerA, new AlphaBetaAI_V1(name = "AI_A", searchDepth = 1), 1)
 
 
-  // Player B (Gote) is an AI player using the stronger AlphaBetaAI_V5.
-  override val playerB: Player = new AIPlayer("AI_PlayerB (Gote)", PlayerB, new AlphaBetaAI_V5(name = "AI_B", searchDepth = 2), 2)
+  // Player B (Gote) is an AI player using the stronger AlphaBetaAI_V6.
+  override val playerB: Player = new AIPlayer("AI_PlayerB (Gote)", PlayerB, new AlphaBetaAI_V6(name = "AI_B", searchDepth = 2), 2)
   // To make Player B a Human Player:
   // override val playerB: Player = new HumanPlayer("Human_PlayerB (Gote)", board, commandReader, true)
   // To use a different AI or search depth for Player B:


### PR DESCRIPTION
## Summary
- implement `QuiescenceSearch` and `AlphaBetaSearchNMPQ`
- add `AlphaBetaAI_V6` that uses quiescence search
- expose new AI via `AIProvider`
- test and console updates to use AI V6
- document new AI in README
- fix compile warnings in `QuiescenceSearch`

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_6840497a619483239cb8baa92f485f0a