### PR TITLE
Fix quiescence search recursion depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ The project includes a comprehensive suite of unit tests. To execute these tests
 
 1.  Open your terminal or command prompt.
 2.  Navigate to the root directory of the project.
-3.  Run the following command:
+3.  Ensure `sbt` is installed (see the [Building from Source](#building-from-source) section).
+4.  Run the following command:
 
     ```sh
     sbt test

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
@@ -72,7 +72,7 @@ object AlphaBetaSearchNMPQ {
     }
 
     if (depth == 0) {
-      val (score, qNodes) = QuiescenceSearch.search(currentState, currentBoard, currentBoardID, alpha, beta, maximizingPlayer, rootPlayerTurn, evalFunc)
+      val (score, qNodes) = QuiescenceSearch.search(currentState, currentBoard, currentBoardID, alpha, beta, maximizingPlayer, rootPlayerTurn, evalFunc, 0)
       nodesVisited += qNodes - 1
       transpositionTable.put(ttKey, score, depth, None)
       return (score, None, nodesVisited)

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
@@ -8,6 +8,8 @@ import jp.sndyuk.shogi.player.Utils
  * Used by AlphaBetaAI_V6 to reduce the horizon effect.
  */
 object QuiescenceSearch {
+  private val MAX_DEPTH = 16
+
   def search(
       currentState: State,
       currentBoard: Board,
@@ -16,9 +18,15 @@ object QuiescenceSearch {
       beta: Int,
       maximizingPlayer: Boolean,
       rootPlayerTurn: Turn,
-      evalFunc: (Board, Turn) => Int
+      evalFunc: (Board, Turn) => Int,
+      depth: Int = 0
   ): (Int, Long) = {
     var nodesVisited: Long = 1L
+
+    if (depth >= MAX_DEPTH) {
+      val standPatEval = evalFunc(currentBoard, rootPlayerTurn)
+      return (standPatEval, nodesVisited)
+    }
 
     // Stand pat evaluation from the perspective of rootPlayerTurn
     val standPat = evalFunc(currentBoard, rootPlayerTurn)
@@ -42,7 +50,7 @@ object QuiescenceSearch {
         val tempBoard = currentBoard.copy()
         val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
         val nextID = ID(tempBoard)
-        val (score, childNodes) = search(nextState, tempBoard, nextID, alphaVar, b, maximizingPlayer = false, rootPlayerTurn, evalFunc)
+        val (score, childNodes) = search(nextState, tempBoard, nextID, alphaVar, b, maximizingPlayer = false, rootPlayerTurn, evalFunc, depth + 1)
         nodesVisited += childNodes
         if (score > bestEval) bestEval = score
         if (score > alphaVar) alphaVar = score
@@ -56,7 +64,7 @@ object QuiescenceSearch {
         val tempBoard = currentBoard.copy()
         val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
         val nextID = ID(tempBoard)
-        val (score, childNodes) = search(nextState, tempBoard, nextID, a, betaVar, maximizingPlayer = true, rootPlayerTurn, evalFunc)
+        val (score, childNodes) = search(nextState, tempBoard, nextID, a, betaVar, maximizingPlayer = true, rootPlayerTurn, evalFunc, depth + 1)
         nodesVisited += childNodes
         if (score < bestEval) bestEval = score
         if (score < betaVar) betaVar = score


### PR DESCRIPTION
## Summary
- cap quiescence search recursion to avoid endless loops
- update AlphaBetaSearchNMPQ to pass starting depth
- document sbt requirement for running tests

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6841779d0d2483239473c67f62cb5180