### PR TITLE
Fix quiescence repetition loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ The project includes a comprehensive suite of unit tests. To execute these tests
 
 1.  Open your terminal or command prompt.
 2.  Navigate to the root directory of the project.
-3.  Run the following command:
+3.  Ensure `sbt` is installed (see the [Building from Source](#building-from-source) section).
+4.  Run the following command:
 
     ```sh
     sbt test

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
@@ -72,7 +72,18 @@ object AlphaBetaSearchNMPQ {
     }
 
     if (depth == 0) {
-      val (score, qNodes) = QuiescenceSearch.search(currentState, currentBoard, currentBoardID, alpha, beta, maximizingPlayer, rootPlayerTurn, evalFunc)
+      val (score, qNodes) = QuiescenceSearch.search(
+        currentState,
+        currentBoard,
+        currentBoardID,
+        alpha,
+        beta,
+        maximizingPlayer,
+        rootPlayerTurn,
+        evalFunc,
+        currentBoardID :: gamePathHistoryIDs,
+        0
+      )
       nodesVisited += qNodes - 1
       transpositionTable.put(ttKey, score, depth, None)
       return (score, None, nodesVisited)

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
@@ -8,6 +8,8 @@ import jp.sndyuk.shogi.player.Utils
  * Used by AlphaBetaAI_V6 to reduce the horizon effect.
  */
 object QuiescenceSearch {
+  private val MAX_DEPTH = 16
+
   def search(
       currentState: State,
       currentBoard: Board,
@@ -16,9 +18,20 @@ object QuiescenceSearch {
       beta: Int,
       maximizingPlayer: Boolean,
       rootPlayerTurn: Turn,
-      evalFunc: (Board, Turn) => Int
+      evalFunc: (Board, Turn) => Int,
+      gamePathHistoryIDs: List[ID] = Nil,
+      depth: Int = 0
   ): (Int, Long) = {
     var nodesVisited: Long = 1L
+
+    if (gamePathHistoryIDs.count(_ == currentBoardID) >= 2) {
+      return (0, nodesVisited)
+    }
+
+    if (depth >= MAX_DEPTH) {
+      val standPatEval = evalFunc(currentBoard, rootPlayerTurn)
+      return (standPatEval, nodesVisited)
+    }
 
     // Stand pat evaluation from the perspective of rootPlayerTurn
     val standPat = evalFunc(currentBoard, rootPlayerTurn)
@@ -42,7 +55,9 @@ object QuiescenceSearch {
         val tempBoard = currentBoard.copy()
         val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
         val nextID = ID(tempBoard)
-        val (score, childNodes) = search(nextState, tempBoard, nextID, alphaVar, b, maximizingPlayer = false, rootPlayerTurn, evalFunc)
+        val (score, childNodes) = search(nextState, tempBoard, nextID, alphaVar, b,
+          maximizingPlayer = false, rootPlayerTurn, evalFunc,
+          currentBoardID :: gamePathHistoryIDs, depth + 1)
         nodesVisited += childNodes
         if (score > bestEval) bestEval = score
         if (score > alphaVar) alphaVar = score
@@ -56,7 +71,9 @@ object QuiescenceSearch {
         val tempBoard = currentBoard.copy()
         val nextState = tempBoard.move(currentState, move.oldPos, move.newPos, false, move.nari)
         val nextID = ID(tempBoard)
-        val (score, childNodes) = search(nextState, tempBoard, nextID, a, betaVar, maximizingPlayer = true, rootPlayerTurn, evalFunc)
+        val (score, childNodes) = search(nextState, tempBoard, nextID, a, betaVar,
+          maximizingPlayer = true, rootPlayerTurn, evalFunc,
+          currentBoardID :: gamePathHistoryIDs, depth + 1)
         nodesVisited += childNodes
         if (score < bestEval) bestEval = score
         if (score < betaVar) betaVar = score


### PR DESCRIPTION
## Summary
- stop recursion on repeated boards in quiescence search
- pass position history to quiescence search

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6841779d0d2483239473c67f62cb5180