### PR TITLE
Add evaluation score and AI battle mode

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/GameState.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/GameState.scala
@@ -68,7 +68,8 @@ case class GameState(
     currentTurn: Player, // Player whose turn it is
     capturedPiecesPlayer1: List[SimplePieceType], // Captured pieces by Player 1
     capturedPiecesPlayer2: List[SimplePieceType], // Captured pieces by Player 2
-    gameHistory: List[SimpleTransition] // List of moves or Transition objects
+    gameHistory: List[SimpleTransition], // List of moves or Transition objects
+    evaluationScore: Int // Board evaluation from the perspective of the player to move
 )
 
 object GameState {

--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
@@ -24,8 +24,9 @@ class ShogiGameService {
 
   var board: Board = _
   var currentState: State = _
-  var aiOpponent: Option[ShogiAI] = None
-  var gameMode: String = "hvh" // "hvh", "hva_sente", "hva_gote"
+  var aiOpponentSente: Option[ShogiAI] = None
+  var aiOpponentGote: Option[ShogiAI] = None
+  var gameMode: String = "hvh" // "hvh", "hva_sente", "hva_gote", "ava"
   var aiSearchDepth: Int = 3
   // Store the initial setup parameters to aid history replay
   private var initialGameFirstPlayer: Player = Player.SENTE
@@ -55,14 +56,19 @@ class ShogiGameService {
     this.gameMode = gameMode
     this.aiSearchDepth = aiSearchDepth
 
-    if (gameMode == "hva_sente" || gameMode == "hva_gote") {
-      this.aiOpponent = AIProvider.getAI(aiType, this.aiSearchDepth)
-      if (this.aiOpponent.isEmpty) {
-        println(s"Warning: Could not initialize AI with type '$aiType'. Game will be Human vs Human.")
-        // For now, it will default to no AI opponent.
-      }
-    } else {
-      this.aiOpponent = None
+    this.aiOpponentSente = None
+    this.aiOpponentGote = None
+
+    gameMode match {
+      case "hva_sente" =>
+        this.aiOpponentSente = AIProvider.getAI(aiType, this.aiSearchDepth)
+      case "hva_gote" =>
+        this.aiOpponentGote = AIProvider.getAI(aiType, this.aiSearchDepth)
+      case "ava" =>
+        this.aiOpponentSente = AIProvider.getAI(aiType, this.aiSearchDepth)
+        this.aiOpponentGote = AIProvider.getAI(aiType, this.aiSearchDepth)
+      case _ =>
+        // hvh or unknown -> no AI players
     }
 
     this.board = initialBoardSetup match {
@@ -157,7 +163,8 @@ class ShogiGameService {
       currentTurn = currentTurnPlayer,
       capturedPiecesPlayer1 = senteCapturedPieces,
       capturedPiecesPlayer2 = goteCapturedPieces,
-      gameHistory = gameHistoryMapped
+      gameHistory = gameHistoryMapped,
+      evaluationScore = jp.sndyuk.shogi.ai.EvaluationV2.evaluate(this.board, this.currentState.turn)
     )
   }
 
@@ -242,11 +249,14 @@ class ShogiGameService {
 
   def requestAIMove(): Either[String, GameState] = {
     val currentPlayer = GameStateMapper.coreTurnToPlayer(this.currentState.turn)
-    val isAISenteTurn = gameMode == "hva_sente" && currentPlayer == Player.SENTE
-    val isAIGoteTurn = gameMode == "hva_gote" && currentPlayer == Player.GOTE
+    val aiForTurnOpt: Option[ShogiAI] = currentPlayer match {
+      case Player.SENTE if gameMode == "hva_sente" || gameMode == "ava" => aiOpponentSente
+      case Player.GOTE  if gameMode == "hva_gote" || gameMode == "ava" => aiOpponentGote
+      case _ => None
+    }
 
-    if (aiOpponent.isDefined && (isAISenteTurn || isAIGoteTurn)) {
-      aiOpponent.get.findBestMove(this.currentState, this.board, this.currentState.turn, this.aiSearchDepth) match {
+    if (aiForTurnOpt.isDefined) {
+      aiForTurnOpt.get.findBestMove(this.currentState, this.board, this.currentState.turn, this.aiSearchDepth) match {
         case (Some(transition: jp.sndyuk.shogi.core.Transition), nodesVisited) => // FQN for Transition
           // println(s"AI (${if (isAISenteTurn) "SENTE" else "GOTE"}) found move: $transition, Nodes visited: $nodesVisited")
 

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/GameSaverSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/GameSaverSpec.scala
@@ -55,7 +55,8 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
       currentTurn = Player.SENTE,
       capturedPiecesPlayer1 = List(SimplePiece.KA, SimplePiece.FU),
       capturedPiecesPlayer2 = List(SimplePiece.HI),
-      gameHistory = sampleHistory
+      gameHistory = sampleHistory,
+      evaluationScore = 0
     )
 
     val saveResult = GameSaver.saveToFile(originalGameState, filePath.toString)
@@ -84,7 +85,8 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
       currentTurn = Player.SENTE,
       capturedPiecesPlayer1 = Nil,
       capturedPiecesPlayer2 = Nil,
-      gameHistory = emptyHistory
+      gameHistory = emptyHistory,
+      evaluationScore = 0
     )
 
     GameSaver.saveToFile(originalGameState, filePath.toString) should be a 'success
@@ -108,7 +110,8 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
       currentTurn = Player.GOTE,
       capturedPiecesPlayer1 = List(SimplePiece.FU, SimplePiece.FU, SimplePiece.KY),
       capturedPiecesPlayer2 = List(SimplePiece.GI),
-      gameHistory = complexHistory
+      gameHistory = complexHistory,
+      evaluationScore = 0
     )
     GameSaver.saveToFile(originalGameState, filePath.toString) should be a 'success
     val loadedGameState = GameSaver.loadFromFile(filePath.toString).get
@@ -133,7 +136,8 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
       currentTurn = Player.SENTE,
       capturedPiecesPlayer1 = List(SimplePiece.KI),
       capturedPiecesPlayer2 = Nil,
-      gameHistory = emptyHistory
+      gameHistory = emptyHistory,
+      evaluationScore = 0
     )
     GameSaver.saveToFile(originalGameState, filePath.toString) should be a 'success
     val loadedGameState = GameSaver.loadFromFile(filePath.toString).get
@@ -151,7 +155,8 @@ class GameSaverSpec extends AnyFlatSpec with Matchers {
       currentTurn = Player.GOTE,
       capturedPiecesPlayer1 = List(SimplePiece.HI, SimplePiece.KA, SimplePiece.FU, SimplePiece.FU),
       capturedPiecesPlayer2 = List(SimplePiece.KI, SimplePiece.GI, SimplePiece.KE, SimplePiece.KY),
-      gameHistory = sampleHistory // sampleHistory already uses PieceInfo in its boardStateAfterMove
+      gameHistory = sampleHistory, // sampleHistory already uses PieceInfo in its boardStateAfterMove
+      evaluationScore = 0
     )
     GameSaver.saveToFile(originalGameState, filePath.toString) should be a 'success
     val loadedGameState = GameSaver.loadFromFile(filePath.toString).get

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/ShogiGameServiceSpec.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/ShogiGameServiceSpec.scala
@@ -12,8 +12,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame(gameMode = "hva_sente", aiType = "v2", aiSearchDepth = 2)
 
     service.gameMode shouldBe "hva_sente"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V2]
+    service.aiOpponentSente shouldBe defined
+    service.aiOpponentSente.get shouldBe an [AlphaBetaAI_V2]
     service.aiSearchDepth shouldBe 2 // Check the service's field
     service.getGameState().currentTurn shouldBe Player.SENTE // Initial turn is Sente
   }
@@ -23,8 +23,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame(gameMode = "hva_gote", aiType = "v1", aiSearchDepth = 4, firstPlayer = Player.SENTE)
 
     service.gameMode shouldBe "hva_gote"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V1]
+    service.aiOpponentGote shouldBe defined
+    service.aiOpponentGote.get shouldBe an [AlphaBetaAI_V1]
     service.aiSearchDepth shouldBe 4 // Check the service's field
     service.getGameState().currentTurn shouldBe Player.SENTE // Initial turn is still Sente
   }
@@ -34,8 +34,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame(gameMode = "hva_sente", aiType = "v4", aiSearchDepth = 2)
 
     service.gameMode shouldBe "hva_sente"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V4]
+    service.aiOpponentSente shouldBe defined
+    service.aiOpponentSente.get shouldBe an [AlphaBetaAI_V4]
     service.aiSearchDepth shouldBe 2
   }
 
@@ -44,8 +44,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame(gameMode = "hva_sente", aiType = "v5", aiSearchDepth = 2)
 
     service.gameMode shouldBe "hva_sente"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V5]
+    service.aiOpponentSente shouldBe defined
+    service.aiOpponentSente.get shouldBe an [AlphaBetaAI_V5]
     service.aiSearchDepth shouldBe 2
   }
 
@@ -54,8 +54,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame(gameMode = "hva_sente", aiType = "v6", aiSearchDepth = 2)
 
     service.gameMode shouldBe "hva_sente"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V6]
+    service.aiOpponentSente shouldBe defined
+    service.aiOpponentSente.get shouldBe an [AlphaBetaAI_V6]
     service.aiSearchDepth shouldBe 2
   }
 
@@ -64,7 +64,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame(gameMode = "hvh") // Default AI type and depth don't matter here
 
     service.gameMode shouldBe "hvh"
-    service.aiOpponent shouldBe None
+    service.aiOpponentSente shouldBe None
+    service.aiOpponentGote shouldBe None
     service.getGameState().currentTurn shouldBe Player.SENTE
   }
 
@@ -73,21 +74,22 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     service.startNewGame()
 
     service.gameMode shouldBe "hvh" // Default in startNewGame signature
-    service.aiOpponent shouldBe None // Because it's hvh
+    service.aiOpponentSente shouldBe None // Because it's hvh
+    service.aiOpponentGote shouldBe None
   }
 
   it should "use the specified aiType and aiSearchDepth when AI is configured" in {
     val service = new ShogiGameService()
     service.startNewGame(gameMode = "hva_sente", aiType = "v1", aiSearchDepth = 1)
     service.gameMode shouldBe "hva_sente"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V1]
+    service.aiOpponentSente shouldBe defined
+    service.aiOpponentSente.get shouldBe an [AlphaBetaAI_V1]
     service.aiSearchDepth shouldBe 1 // Check the service's field
 
     service.startNewGame(gameMode = "hva_gote", aiType = "v2", aiSearchDepth = 5)
     service.gameMode shouldBe "hva_gote"
-    service.aiOpponent shouldBe defined
-    service.aiOpponent.get shouldBe an [AlphaBetaAI_V2]
+    service.aiOpponentGote shouldBe defined
+    service.aiOpponentGote.get shouldBe an [AlphaBetaAI_V2]
     service.aiSearchDepth shouldBe 5 // Check the service's field
   }
 
@@ -96,7 +98,8 @@ class ShogiGameServiceSpec extends AnyFlatSpec with Matchers {
     // Suppress warning output during test if any, though current implementation doesn't log to console
     service.startNewGame(gameMode = "hva_sente", aiType = "non_existent_ai", aiSearchDepth = 3)
     service.gameMode shouldBe "hva_sente" // mode is set
-    service.aiOpponent shouldBe None // AI opponent is None due to invalid type
+    service.aiOpponentSente shouldBe None // AI opponent is None due to invalid type
+    service.aiOpponentGote shouldBe None
   }
 
   "ShogiGameService (AI Moves - requestAIMove)" should "allow AI Sente to make the first move" in {

--- a/src/core/src/test/scala/jp/sndyuk/shogi/core/simulation/CoreAIBattleSim.scala
+++ b/src/core/src/test/scala/jp/sndyuk/shogi/core/simulation/CoreAIBattleSim.scala
@@ -60,6 +60,9 @@ object CoreAIBattleSim extends App { // Changed object name
 
         currentState = board.move(currentState, move.oldPos, move.newPos, false, move.nari)
 
+        val evalScore = EvaluationV2.evaluate(board, currentState.turn)
+        println(s"Evaluation for ${currentState.turn}: $evalScore")
+
         val newBoardSquaresId = board.squares.id()
         val newCapturedPiecesId = board.capturedPieces.id()
         val newPositionKey = (newBoardSquaresId, newCapturedPiecesId, currentState.turn)

--- a/src/sample/src/main/scala/jp/sndyuk/shogi/ui/AIBattleSim.scala
+++ b/src/sample/src/main/scala/jp/sndyuk/shogi/ui/AIBattleSim.scala
@@ -106,6 +106,9 @@ object AIBattleSim extends App {
         // After board.move, currentState.turn is updated to be the *next* player's turn.
         // The board object itself has been mutated by the move.
 
+        val evalScore = EvaluationV2.evaluate(board, currentState.turn)
+        println(s"Evaluation for ${currentState.turn}: $evalScore")
+
         // Sennichite (Four-fold repetition) check:
         // A game position is defined by the placement of pieces on the board, the pieces in each player's hand, and whose turn it is to move.
         // If the exact same game position occurs four times, the game is a draw due to Sennichite.

--- a/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Gui.scala
+++ b/src/sample/src/main/scala/jp/sndyuk/shogi/ui/Gui.scala
@@ -375,7 +375,8 @@ object Gui extends SimpleSwingApplication with Shogi {
         currentTurn = GameStateMapper.coreTurnToPlayer(currState.turn), // Returns CorePlayer.Player
         capturedPiecesPlayer1 = capturedSente, // List[SimplePiece.SimplePieceType]
         capturedPiecesPlayer2 = capturedGote, // List[SimplePiece.SimplePieceType]
-        gameHistory = gameHistoryMapped
+        gameHistory = gameHistoryMapped,
+        evaluationScore = 0
       )
 
       GameSaver.saveToFile(gameStateToSave, file.getAbsolutePath) match {

--- a/src/web/src/main/resources/webroot/app.js
+++ b/src/web/src/main/resources/webroot/app.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const newGameBtn = document.getElementById('new-game-btn');
     const battleModeSelect = document.getElementById('battle-mode');
     const suggestMoveBtn = document.getElementById('suggest-move-btn');
+    const evaluationScoreDiv = document.getElementById('evaluation-score');
 
     let selectedPiece = null; // { x, y, pieceType, player, isPromoted } or { pieceTypeToDrop, player }
     let currentTurn = null;   // Will be 'SENTE' or 'GOTE' (string based on Player enum)
@@ -60,9 +61,14 @@ document.addEventListener('DOMContentLoaded', () => {
             renderBoard(boardState); // use converted board state
             renderCapturedPieces(gameState.capturedPiecesPlayer1, gameState.capturedPiecesPlayer2);
             updateGameStatus(`Turn: ${currentTurn}. History moves: ${gameState.gameHistory.length}`);
+            updateEvaluationScore(gameState.evaluationScore);
             clearHighlights();
             selectedPiece = null;
             currentBattleMode = battleModeSelect.value; // Ensure mode is current
+
+            if (currentBattleMode === 'AI_VS_AI') {
+                setTimeout(requestAIMove, 100);
+            }
 
         } catch (error) {
             console.error('Failed to fetch game state:', error);
@@ -289,6 +295,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Optionally, specify AI type and depth if desired from frontend
                 // requestBody.aiType = "v2";
                 // requestBody.aiSearchDepth = 3;
+            } else if (currentBattleMode === 'AI_VS_AI') {
+                requestBody.gameMode = 'ava';
             } else { // HUMAN_VS_HUMAN
                 requestBody.gameMode = 'hvh';
             }
@@ -308,6 +316,9 @@ document.addEventListener('DOMContentLoaded', () => {
             // currentBattleMode is already updated from selector value above
             updateGameStatus(`New game started. Mode: ${currentBattleMode}. Turn: ${newGameState.currentTurn}`);
             await fetchGameState(); // Refresh state (this will also update currentTurn from gameState)
+            if (currentBattleMode === 'AI_VS_AI') {
+                setTimeout(requestAIMove, 100);
+            }
         } catch (error) {
             console.error('Failed to start new game:', error);
             updateGameStatus(`New game error: ${error.message}`);
@@ -318,6 +329,10 @@ document.addEventListener('DOMContentLoaded', () => {
         gameStatusDiv.innerHTML = `<p>${message}</p>`;
     }
 
+    function updateEvaluationScore(score) {
+        evaluationScoreDiv.textContent = `Evaluation: ${score}`;
+    }
+
     async function requestAIMove() {
         if (currentTurn === null) {
             console.log("Cannot request AI move, current turn is null.");
@@ -326,7 +341,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // Determine which player is AI based on currentBattleMode and currentTurn
         // For now, assuming Sente is Human and Gote is AI in HUMAN_VS_AI mode
         // This logic might need adjustment if player roles can be swapped.
-        const isAIsTurn = (currentBattleMode === 'HUMAN_VS_AI' && currentTurn === 'GOTE'); // Example: Gote is AI
+        const isAIsTurn = (
+            (currentBattleMode === 'HUMAN_VS_AI' && currentTurn === 'GOTE') ||
+            currentBattleMode === 'AI_VS_AI'
+        );
 
         if (!isAIsTurn) {
             console.log("Not AI's turn or not in AI mode.");
@@ -347,6 +365,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             updateGameStatus(`AI (${currentTurn}) moved. Turn: ${result.currentTurn}.`);
             await fetchGameState(); // Refresh entire state after AI move
+            if (currentBattleMode === 'AI_VS_AI') {
+                setTimeout(requestAIMove, 100);
+            }
         } catch (error) {
             console.error('AI move failed:', error);
             updateGameStatus(`AI move error: ${error.message}. Turn: ${currentTurn}.`);

--- a/src/web/src/main/resources/webroot/index.html
+++ b/src/web/src/main/resources/webroot/index.html
@@ -34,10 +34,13 @@
             <select id="battle-mode">
                 <option value="HUMAN_VS_HUMAN" selected>Human vs Human</option>
                 <option value="HUMAN_VS_AI">Human vs AI</option>
+                <option value="AI_VS_AI">AI vs AI</option>
             </select>
         </div>
         <button id="suggest-move-btn">Suggest Move</button>
     </div>
+
+    <div id="evaluation-score"></div>
 
     <button id="new-game-btn">New Game</button>
 


### PR DESCRIPTION
## Summary
- show board evaluation score in `GameState`
- print evaluation after each move in AI battle sims
- support AI-vs-AI mode in `ShogiGameService`
- surface evaluation and new battle mode in the web UI
- fixed compile errors in GUI save logic and updated tests

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y sbt`
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_684178565e7883238ace29d33c5483de