### PR TITLE
Fix potential infinite loop in AI search

### DIFF
--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaSearchNMPQ.scala
@@ -67,7 +67,7 @@ object AlphaBetaSearchNMPQ {
     }
     val ttMove = ttEntryOpt.flatMap(_.bestMove)
 
-    if (gamePathHistoryIDs.count(_ == currentBoardID) >= 2) {
+    if (gamePathHistoryIDs.contains(currentBoardID)) {
       return (0, None, nodesVisited)
     }
 

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/QuiescenceSearch.scala
@@ -23,7 +23,7 @@ object QuiescenceSearch {
       depth: Int = 0
   ): (Int, Long) = {
     var nodesVisited: Long = 1L
-    if (gamePathHistoryIDs.count(_ == currentBoardID) >= 2) {
+    if (gamePathHistoryIDs.contains(currentBoardID)) {
       return (0, nodesVisited)
     }
     if (depth >= MAX_DEPTH) {


### PR DESCRIPTION
The AI could enter an infinite loop due to a lenient repetition check in the search algorithms. The check `gamePathHistoryIDs.count(_ == currentBoardID) >= 2` failed to detect cycles in the search path where a state repeated before reaching a third occurrence.

This commit changes the repetition check to `gamePathHistoryIDs.contains(currentBoardID)` in both `AlphaBetaSearchNMPQ.scala` and `QuiescenceSearch.scala`. This stricter check correctly identifies if the current board state has appeared previously in the current search path, thus preventing loops.