### PR TITLE
Add opening book and new AI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Shogi library for Scala.
 - **AI Opponent:** Play against a built-in AI.
 - **Advanced AI Version 5:** Utilizes a transposition table, Null Move Pruning, and killer move heuristics for stronger play.
 - **Advanced AI Version 6:** Adds quiescence search to V5's techniques for even deeper tactical strength.
+- **Advanced AI Version 7:** Uses a small built-in opening book before searching, improving early play.
 - **Kifu Parsing:** Support for reading game records in CSA and KI2 formats.
 - **Player Management:** Code structure for managing human and AI players.
 - **Sample GUI Application:** Includes a basic graphical interface to demonstrate library usage.

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V7.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/AlphaBetaAI_V7.scala
@@ -1,0 +1,28 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{State, Board, Turn, Transition}
+
+/**
+ * AlphaBetaAI_V7 extends V6 by consulting a small
+ * built-in opening book before running the main search.
+ * If the current board position is found in the book,
+ * the recommended move is played immediately.
+ */
+class AlphaBetaAI_V7(val name: String = "AlphaBetaAI_V7", searchDepth: Int) extends ShogiAI {
+
+  private val coreAI = new AlphaBetaAI_V6(name + "_core", searchDepth)
+
+  override def findBestMove(
+      state: State,
+      board: Board,
+      turn: Turn,
+      currentSearchDepth: Int
+  ): (Option[Transition], Long) = {
+    OpeningBook.get(board) match {
+      case Some(bookMove) => (Some(bookMove), 0L)
+      case None => coreAI.findBestMove(state, board, turn, currentSearchDepth)
+    }
+  }
+
+  override def toString: String = s"$name(depth=$searchDepth)"
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/ai/OpeningBook.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/ai/OpeningBook.scala
@@ -1,0 +1,28 @@
+package jp.sndyuk.shogi.ai
+
+import jp.sndyuk.shogi.core.{Board, ID, Transition}
+
+/**
+ * Very small built-in opening book.  It currently only
+ * contains moves from the standard initial position.
+ * Keys are board position hashes and values are the
+ * recommended Transition from that position.
+ */
+object OpeningBook {
+  private val book: Map[Long, Transition] = {
+    val initBoard = Board()
+    val firstMove = Transition(
+      Board.humanReadableToPoint(7, 7),
+      Board.humanReadableToPoint(7, 6),
+      nari = false,
+      captured = None
+    )
+    Map(ID(initBoard).hashLong -> firstMove)
+  }
+
+  /**
+   * Returns an opening book move for the given board, if available.
+   */
+  def get(board: Board): Option[Transition] =
+    book.get(ID(board).hashLong)
+}

--- a/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
+++ b/src/core/src/main/scala/jp/sndyuk/shogi/core/ShogiGameService.scala
@@ -2,7 +2,7 @@ package jp.sndyuk.shogi.core
 
 import jp.sndyuk.shogi.core.Player.Player
 import jp.sndyuk.shogi.core.SimplePiece.SimplePieceType
-import jp.sndyuk.shogi.ai.{ShogiAI, AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V3, AlphaBetaAI_V4, AlphaBetaAI_V5, AlphaBetaAI_V6}
+import jp.sndyuk.shogi.ai.{ShogiAI, AlphaBetaAI_V1, AlphaBetaAI_V2, AlphaBetaAI_V3, AlphaBetaAI_V4, AlphaBetaAI_V5, AlphaBetaAI_V6, AlphaBetaAI_V7}
 import play.api.libs.json.{Json, JsValue, JsNumber, JsString, JsBoolean}
 
 object AIProvider {
@@ -14,6 +14,7 @@ object AIProvider {
       case "v4" => Some(new AlphaBetaAI_V4("AlphaBetaAI_V4", searchDepth))
       case "v5" => Some(new AlphaBetaAI_V5("AlphaBetaAI_V5", searchDepth))
       case "v6" => Some(new AlphaBetaAI_V6("AlphaBetaAI_V6", searchDepth))
+      case "v7" => Some(new AlphaBetaAI_V7("AlphaBetaAI_V7", searchDepth))
       case _    => None
     }
   }


### PR DESCRIPTION
## Summary
- introduce `OpeningBook` with a small builtin opening
- create `AlphaBetaAI_V7` that uses the opening book and falls back to V6
- enable selection of the new AI in `ShogiGameService`
- mention new AI version in README

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_684eb7a320888323b2e3868760fc587a